### PR TITLE
Feat/vm hardening

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ CLAUDE.md
 .idea/
 .vscode/
 *.user
+
+# Private planning docs (never commit)
+docs/VM_HARDENING_PLAN.md

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,10 @@ CMakeCache.txt
 CMakeFiles/
 cmake_install.cmake
 
+# run tests dirs 
+obf_reports/
+obf_rt_work/
+
 # Compiled objects / libs / plugins
 *.o
 *.obj

--- a/VMPass.cpp
+++ b/VMPass.cpp
@@ -66,6 +66,7 @@ VMPassConfig VMPassConfig::fromPassConfig(const PassConfig& PC) {
 	getUInt("nestedVMOpcodes", Cfg.nestedVMOpcodes);
 	getBool("nestedVMHardened", Cfg.nestedVMHardened);
 	getBool("threadedDispatch", Cfg.threadedDispatch);
+	getBool("keyedDispatch", Cfg.keyedDispatch);
 
 	// useAES requires encBytecode — if the user disabled encryption entirely,
 	// AES has nothing to replace.

--- a/VMPass.cpp
+++ b/VMPass.cpp
@@ -65,6 +65,7 @@ VMPassConfig VMPassConfig::fromPassConfig(const PassConfig& PC) {
 	getBool("nestedVM", Cfg.nestedVM);
 	getUInt("nestedVMOpcodes", Cfg.nestedVMOpcodes);
 	getBool("nestedVMHardened", Cfg.nestedVMHardened);
+	getBool("threadedDispatch", Cfg.threadedDispatch);
 
 	// useAES requires encBytecode — if the user disabled encryption entirely,
 	// AES has nothing to replace.

--- a/VMPass.cpp
+++ b/VMPass.cpp
@@ -62,6 +62,9 @@ VMPassConfig VMPassConfig::fromPassConfig(const PassConfig& PC) {
 	getUInt("adDispatchInterval", Cfg.adDispatchInterval);
 	getUInt("adHandlerProb", Cfg.adHandlerProb);
 	getUInt("handlerVariants", Cfg.handlerVariants);
+	getBool("nestedVM", Cfg.nestedVM);
+	getUInt("nestedVMOpcodes", Cfg.nestedVMOpcodes);
+	getBool("nestedVMHardened", Cfg.nestedVMHardened);
 
 	// useAES requires encBytecode — if the user disabled encryption entirely,
 	// AES has nothing to replace.

--- a/VMPass.cpp
+++ b/VMPass.cpp
@@ -48,6 +48,7 @@ VMPassConfig VMPassConfig::fromPassConfig(const PassConfig& PC) {
 	getBool("obfRegIdx", Cfg.obfRegIdx);
 	getBool("encDispatch", Cfg.encDispatch);
 	getBool("encBytecode", Cfg.encBytecode);
+	getBool("constInStream", Cfg.constInStream);
 	getBool("strongBytecode", Cfg.strongBytecode);
 	getBool("blindTargets", Cfg.blindTargets);
 	getBool("useAES", Cfg.useAES);
@@ -69,6 +70,9 @@ VMPassConfig VMPassConfig::fromPassConfig(const PassConfig& PC) {
 	if (!Cfg.useAES) Cfg.lazyDecrypt = false;
 	// hardened requires encBytecode (meaningful only with encrypted bytecode)
 	if (!Cfg.encBytecode) Cfg.hardened = false;
+	// constInStream requires encBytecode — the whole point is to hide constants
+	// in the encrypted stream instead of plaintext wrapper stores.
+	if (!Cfg.encBytecode) Cfg.constInStream = false;
 	// hardened implies regEncrypt — encrypted registers complement MBA-obscured handlers
 	if (Cfg.hardened) Cfg.regEncrypt = true;
 	if (Cfg.handlerVariants < 1) Cfg.handlerVariants = 1;

--- a/VMPass.cpp
+++ b/VMPass.cpp
@@ -51,6 +51,7 @@ VMPassConfig VMPassConfig::fromPassConfig(const PassConfig& PC) {
 	getBool("strongBytecode", Cfg.strongBytecode);
 	getBool("blindTargets", Cfg.blindTargets);
 	getBool("useAES", Cfg.useAES);
+	getBool("lazyDecrypt", Cfg.lazyDecrypt);
 	getBool("hardened", Cfg.hardened);
 	getBool("regEncrypt", Cfg.regEncrypt);
 	getBool("rollingRegKey", Cfg.rollingRegKey);
@@ -64,6 +65,8 @@ VMPassConfig VMPassConfig::fromPassConfig(const PassConfig& PC) {
 	// useAES requires encBytecode — if the user disabled encryption entirely,
 	// AES has nothing to replace.
 	if (!Cfg.encBytecode) Cfg.useAES = false;
+	// lazyDecrypt requires useAES — nothing to defer if AES isn't the cipher.
+	if (!Cfg.useAES) Cfg.lazyDecrypt = false;
 	// hardened requires encBytecode (meaningful only with encrypted bytecode)
 	if (!Cfg.encBytecode) Cfg.hardened = false;
 	// hardened implies regEncrypt — encrypted registers complement MBA-obscured handlers

--- a/VMPass_Emitter.cpp
+++ b/VMPass_Emitter.cpp
@@ -955,6 +955,11 @@ bool BytecodeEmitter::run(Function& F, uint8_t S, const DataLayout& D) {
 		SmallVector<uint8_t, 1024> Body;
 		Body.swap(BC);
 
+		// keyedDispatch: every position recorded in KeyedOpIPs so far belongs to
+		// the body (the prologue hasn't been written yet) and was baked with a
+		// key computed against its pre-splice IP -- see the re-key loop below.
+		size_t BodyOpCount = KeyedOpIPs.size();
+
 		for (auto& KV : ImmLoads) {
 			bop(OP_LOADI);
 			b8(xorSalt(KV.first));
@@ -976,6 +981,19 @@ bool BytecodeEmitter::run(Function& F, uint8_t S, const DataLayout& D) {
 
 		uint32_t PrologueLen = ip();
 		BC.append(Body.begin(), Body.end());
+
+		// keyedDispatch: re-key every body opcode byte now that its final
+		// (post-splice) IP is known -- strip the stale pre-splice mask and apply
+		// the correct one. Prologue opcode bytes (recorded after BodyOpCount)
+		// were already written at their final IP and are left untouched.
+		if (KeyedDispatch) {
+			for (size_t i = 0; i < BodyOpCount; ++i) {
+				uint32_t OldIP = KeyedOpIPs[i];
+				uint32_t NewIP = OldIP + PrologueLen;
+				BC[NewIP] ^= opKeyByteCT(KeyedSalt, OldIP) ^ opKeyByteCT(KeyedSalt, NewIP);
+				KeyedOpIPs[i] = NewIP;
+			}
+		}
 
 		for (auto& KV : BlockIP) KV.second += PrologueLen;
 		for (Fixup& FX : Fixups) FX.Offset += PrologueLen;

--- a/VMPass_Emitter.cpp
+++ b/VMPass_Emitter.cpp
@@ -942,6 +942,62 @@ bool BytecodeEmitter::run(Function& F, uint8_t S, const DataLayout& D) {
 	// Forward branch targets are recorded as Fixups with a 0x00000000 placeholder.
 	for (BasicBlock& BB : F) emit(&BB);
 
+	// constInStream: move int/i64/fp constant slot seeding out of the plaintext
+	// wrapper preload stores and into the encrypted bytecode stream as a
+	// prologue. ImmLoads/ImmLoads64/ImmLoadsF are only fully populated once the
+	// block-emission loop above has walked every instruction operand (vr()/
+	// vr64()/fr() append to them lazily on first use), so the prologue can only
+	// be built afterwards. It is then spliced in front of the already-emitted
+	// block bytes; every recorded offset (BlockIP entries, Fixup placeholders)
+	// is shifted by the prologue length so branch targets and the fixup patch
+	// loop below still resolve correctly.
+	if (ConstInStream && !Unsupported) {
+		SmallVector<uint8_t, 1024> Body;
+		Body.swap(BC);
+
+		for (auto& KV : ImmLoads) {
+			bop(OP_LOADI);
+			b8(xorSalt(KV.first));
+			u32((uint32_t)KV.second->getZExtValue());
+		}
+		for (auto& KV : ImmLoads64) {
+			bop(OP_LOADI64);
+			b8(xorSalt(KV.first));
+			u64(KV.second->getZExtValue());
+		}
+		for (auto& KV : ImmLoadsF) {
+			bop(OP_LOADI_F);
+			b8(xorSalt(KV.first));
+			double DV = KV.second->getType()->isDoubleTy()
+				? KV.second->getValueAPF().convertToDouble()
+				: (double)KV.second->getValueAPF().convertToFloat();
+			f64(DV);
+		}
+
+		uint32_t PrologueLen = ip();
+		BC.append(Body.begin(), Body.end());
+
+		for (auto& KV : BlockIP) KV.second += PrologueLen;
+		for (Fixup& FX : Fixups) FX.Offset += PrologueLen;
+
+		// Nothing branches to IP=0 directly (the prologue falls through into
+		// the now-shifted entry block), but the verifier requires IP=0 itself
+		// to be a recognised block start since that is where the interpreter
+		// begins fetching. Record it under a null key -- BlockIP is only ever
+		// read for its values (verifier) or looked up by real BasicBlock*
+		// fixup targets (patch loop below), never iterated by key, so a
+		// null-keyed marker entry is safe.
+		BlockIP[nullptr] = 0;
+
+		// These three constant kinds are now seeded by the prologue above, not
+		// by the wrapper's plaintext preload stores. Pointer constants
+		// (PtrLoads) are left untouched — they are relocations, not secrets,
+		// and stay in the wrapper.
+		ImmLoads.clear();
+		ImmLoads64.clear();
+		ImmLoadsF.clear();
+	}
+
 	// Patch all forward-branch placeholders now that every BlockIP is known.
 	for (const Fixup& FX : Fixups) {
 		uint32_t V = BlockIP.lookup(FX.Target);

--- a/VMPass_Impl.cpp
+++ b/VMPass_Impl.cpp
@@ -280,7 +280,7 @@ void VMImpl::buildCalleeGlobal() {
 	auto* ATy = ArrayType::get(PtrTy, Cs.size());
 	// writable when hardened (callee XOR ctor modifies in-place)
 	GVCallees = new GlobalVariable(M, ATy,
-		/*isConstant=*/!VCtx.Cfg.hardened,
+		/*isConstant=*/!Cfg.hardened,
 		GlobalValue::PrivateLinkage,
 		ConstantArray::get(ATy, Cs), (F.getName() + ".vm.callees").str());
 	GVCallees->setUnnamedAddr(GlobalValue::UnnamedAddr::Global);
@@ -288,7 +288,7 @@ void VMImpl::buildCalleeGlobal() {
 
 	// emit GVFTyIndices [C x i8] and populate shared FTy registry.
 	UniqueFTys.clear();
-	auto* SS = VMEngine::getSharedState(M);
+	auto* SS = VMEngine::getSharedState(M, EngineId);
 	SmallVector<uint8_t, 8> IdxBytes;
 	IdxBytes.reserve(E.CalleeFTyTab.size());
 	for (FunctionType* FTy : E.CalleeFTyTab) {
@@ -409,6 +409,497 @@ void VMImpl::buildVMEntry()
 
 
 
+// ============================================================================
+// Nested-VM
+//
+// Concept: an eligible opcode's compute step is a call to a pure helper
+// function, and that helper is itself virtualized. Executing one outer
+// nested-eligible instruction therefore drives a full inner VM dispatch loop
+// -- depth-2 interpretation. Eligible opcodes: BINOP, BINOP64, ICMP, ICMP64,
+// FCMP, CAST (kNestedHelperOrder below; the nestedVMOpcodes cap -- see
+// opcodeNests() -- selects a prefix of this fixed order).
+//
+// Two engines, not a runtime flag on one: a build with NestedVM=true targets
+// EngineId 1 (@__vm_engine.nest), whose nested-eligible handlers call their
+// helper. Every helper is always inner-virtualized with nestedVM=false, so it
+// targets EngineId 0 (@__vm_engine), whose handlers compute inline. This is
+// what makes recursion terminate: a helper's own bytecode may itself contain
+// nested-eligible opcodes (its body is a plain switch like any other
+// function), but those run through the PLAIN engine, which never calls back
+// into a helper. An earlier version of this shared one engine for both layers
+// and used the same handler code regardless of which bytecode it was
+// interpreting -- that recursed unboundedly (engine -> helper -> engine ->
+// helper -> ...) and stack-overflowed at runtime; see EngineId below.
+//
+// Sequencing (see call sites in run()):
+//   1. getOrCreateNestedHelper(Op) runs BEFORE populateVMEngine(), once per
+//      eligible Op. It only creates the helper Function with a plain
+//      (non-virtualized) switch body -- the opcode's handler case needs the
+//      Function* to exist so it can emit a call to it.
+//   2. populateVMEngine() builds EngineId 1's (@__vm_engine.nest) handler
+//      blocks as normal (first NestedVM function only; independent of, and
+//      does not perturb, EngineId 0's SharedState).
+//   3. virtualizeNestedHelpersOnce() runs AFTER populateVMEngine(), guarded
+//      to run once per module. For every helper Function that was created,
+//      this replaces its plain body with a VM wrapper by running a second,
+//      independent VMImpl over it with nestedVM=false (so it targets
+//      EngineId 0) and a forked RNG.
+//
+// Step 3 MUST come after step 2: with a single shared engine, inner-
+// virtualizing a helper first would make it the one to trigger
+// populateVMEngine()'s "first function" build, baking non-nested handler
+// bodies in permanently. With two independent EngineId-keyed SharedStates
+// this specific failure mode can no longer happen (helpers target id 0,
+// outer targets id 1), but the ordering is kept because it's already been
+// verified correct and step 3 still depends on nothing from step 2 that
+// would change.
+// ============================================================================
+
+namespace {
+	constexpr const char* kNestedBinopHelperName = "__vm_h_binop";
+	constexpr const char* kNestedBinop64HelperName = "__vm_h_binop64";
+	constexpr const char* kNestedIcmpHelperName = "__vm_h_icmp";
+	constexpr const char* kNestedIcmp64HelperName = "__vm_h_icmp64";
+	constexpr const char* kNestedFcmpHelperName = "__vm_h_fcmp";
+	constexpr const char* kNestedCastHelperName = "__vm_h_cast";
+
+	// Fixed deterministic nesting order, consumed by run() (helper creation),
+	// opcodeNests() (the nestedVMOpcodes cap), and virtualizeNestedHelpersOnce()
+	// (inner virtualization). NestedVMOpcodes==N>0 nests only the first N
+	// entries of this list; the rest stay inline.
+	struct NestedHelperDesc { VMOp Op; const char* Name; };
+	constexpr NestedHelperDesc kNestedHelperOrder[] = {
+		{ OP_BINOP,   kNestedBinopHelperName },
+		{ OP_BINOP64, kNestedBinop64HelperName },
+		{ OP_ICMP,    kNestedIcmpHelperName },
+		{ OP_ICMP64,  kNestedIcmp64HelperName },
+		{ OP_FCMP,    kNestedFcmpHelperName },
+		{ OP_CAST,    kNestedCastHelperName },
+	};
+	constexpr unsigned kNumNestedHelpers =
+		sizeof(kNestedHelperOrder) / sizeof(kNestedHelperOrder[0]);
+}
+
+bool VMImpl::opcodeNests(VMOp Op) const {
+	if (!NestedVM) return false;
+	for (unsigned i = 0; i < kNumNestedHelpers; ++i) {
+		if (kNestedHelperOrder[i].Op == Op)
+			return NestedVMOpcodes == 0 || i < NestedVMOpcodes;
+	}
+	return false;
+}
+
+Function* VMImpl::getOrCreateNestedHelper(VMOp Op) {
+	switch (Op) {
+	case OP_BINOP:   return getOrCreateNestedBinopHelper();
+	case OP_BINOP64: return getOrCreateNestedBinop64Helper();
+	case OP_ICMP:    return getOrCreateNestedIcmpHelper();
+	case OP_ICMP64:  return getOrCreateNestedIcmp64Helper();
+	case OP_FCMP:    return getOrCreateNestedFcmpHelper();
+	case OP_CAST:    return getOrCreateNestedCastHelper();
+	default:         return nullptr;
+	}
+}
+
+// Pure helper `i32 __vm_h_binop(i32 a, i32 b, i8 subop)` -- replicates
+// OP_BINOP's subop switch (VMPass_Impl.cpp buildHandlersIntArith) exactly,
+// including using a switch (not a select chain) so div/rem are never
+// speculatively executed for a non-div/rem subop. Idempotent: reused across
+// every nested-eligible function in the module.
+Function* VMImpl::getOrCreateNestedBinopHelper() {
+	if (Function* Existing = M.getFunction(kNestedBinopHelperName))
+		return Existing;
+
+	FunctionType* FTy = FunctionType::get(I32Ty, { I32Ty, I32Ty, I8Ty }, false);
+	Function* HF = Function::Create(FTy, GlobalValue::InternalLinkage,
+		kNestedBinopHelperName, &M);
+	HF->addFnAttr(Attribute::NoUnwind);
+	Argument* AArg = HF->getArg(0); AArg->setName("a");
+	Argument* BArg = HF->getArg(1); BArg->setName("b");
+	Argument* SubArg = HF->getArg(2); SubArg->setName("subop");
+
+	BasicBlock* EntryBB = BasicBlock::Create(Ctx, "entry", HF);
+	IRBuilder<> B(EntryBB);
+	Value* Sub32 = B.CreateZExt(SubArg, I32Ty, "sub32");
+
+	BasicBlock* MergeBB = BasicBlock::Create(Ctx, "merge", HF);
+	BasicBlock* DefBB = BasicBlock::Create(Ctx, "def", HF);
+	SwitchInst* SW = B.CreateSwitch(Sub32, DefBB, 12);
+
+	IRBuilder<> BM(MergeBB);
+	auto* Phi = BM.CreatePHI(I32Ty, 13, "r");
+	BM.CreateRet(Phi);
+
+	{
+		// Default implements BS_ADD (matches OP_BINOP's fallback).
+		IRBuilder<> BD(DefBB);
+		Value* Rv = BD.CreateAdd(AArg, BArg, "add");
+		Phi->addIncoming(Rv, DefBB);
+		BD.CreateBr(MergeBB);
+	}
+
+	auto addCase = [&](uint32_t Case, const Twine& Name, auto Emit) {
+		BasicBlock* CBB = BasicBlock::Create(Ctx, Name, HF);
+		IRBuilder<> BC(CBB);
+		Value* Rv = Emit(BC);
+		Phi->addIncoming(Rv, CBB);
+		BC.CreateBr(MergeBB);
+		SW->addCase(B.getInt32(Case), CBB);
+		};
+
+	addCase(BS_SUB, "sub", [&](IRBuilder<>& BC) { return BC.CreateSub(AArg, BArg, "sub"); });
+	addCase(BS_MUL, "mul", [&](IRBuilder<>& BC) { return BC.CreateMul(AArg, BArg, "mul"); });
+	addCase(BS_AND, "and", [&](IRBuilder<>& BC) { return BC.CreateAnd(AArg, BArg, "and"); });
+	addCase(BS_OR, "or", [&](IRBuilder<>& BC) { return BC.CreateOr(AArg, BArg, "or"); });
+	addCase(BS_XOR, "xor", [&](IRBuilder<>& BC) { return BC.CreateXor(AArg, BArg, "xor"); });
+	addCase(BS_SHL, "shl", [&](IRBuilder<>& BC) { return BC.CreateShl(AArg, BArg, "shl"); });
+	addCase(BS_LSHR, "lshr", [&](IRBuilder<>& BC) { return BC.CreateLShr(AArg, BArg, "lshr"); });
+	addCase(BS_ASHR, "ashr", [&](IRBuilder<>& BC) { return BC.CreateAShr(AArg, BArg, "ashr"); });
+	addCase(BS_SDIV, "sdiv", [&](IRBuilder<>& BC) { return BC.CreateSDiv(AArg, BArg, "sdiv"); });
+	addCase(BS_UDIV, "udiv", [&](IRBuilder<>& BC) { return BC.CreateUDiv(AArg, BArg, "udiv"); });
+	addCase(BS_SREM, "srem", [&](IRBuilder<>& BC) { return BC.CreateSRem(AArg, BArg, "srem"); });
+	addCase(BS_UREM, "urem", [&](IRBuilder<>& BC) { return BC.CreateURem(AArg, BArg, "urem"); });
+
+	return HF;
+}
+
+// Pure helper `i64 __vm_h_binop64(i64 a, i64 b, i8 subop)` -- replicates
+// OP_BINOP64's subop switch (buildHandlersIntArith) exactly, same shape as
+// getOrCreateNestedBinopHelper() but over I64Ty operands/result.
+Function* VMImpl::getOrCreateNestedBinop64Helper() {
+	if (Function* Existing = M.getFunction(kNestedBinop64HelperName))
+		return Existing;
+
+	FunctionType* FTy = FunctionType::get(I64Ty, { I64Ty, I64Ty, I8Ty }, false);
+	Function* HF = Function::Create(FTy, GlobalValue::InternalLinkage,
+		kNestedBinop64HelperName, &M);
+	HF->addFnAttr(Attribute::NoUnwind);
+	Argument* AArg = HF->getArg(0); AArg->setName("a");
+	Argument* BArg = HF->getArg(1); BArg->setName("b");
+	Argument* SubArg = HF->getArg(2); SubArg->setName("subop");
+
+	BasicBlock* EntryBB = BasicBlock::Create(Ctx, "entry", HF);
+	IRBuilder<> B(EntryBB);
+	Value* Sub32 = B.CreateZExt(SubArg, I32Ty, "sub32");
+
+	BasicBlock* MergeBB = BasicBlock::Create(Ctx, "merge", HF);
+	BasicBlock* DefBB = BasicBlock::Create(Ctx, "def", HF);
+	SwitchInst* SW = B.CreateSwitch(Sub32, DefBB, 12);
+
+	IRBuilder<> BM(MergeBB);
+	auto* Phi = BM.CreatePHI(I64Ty, 13, "r");
+	BM.CreateRet(Phi);
+
+	{
+		// Default implements BS_ADD (matches OP_BINOP64's fallback).
+		IRBuilder<> BD(DefBB);
+		Value* Rv = BD.CreateAdd(AArg, BArg, "add");
+		Phi->addIncoming(Rv, DefBB);
+		BD.CreateBr(MergeBB);
+	}
+
+	auto addCase = [&](uint32_t Case, const Twine& Name, auto Emit) {
+		BasicBlock* CBB = BasicBlock::Create(Ctx, Name, HF);
+		IRBuilder<> BC(CBB);
+		Value* Rv = Emit(BC);
+		Phi->addIncoming(Rv, CBB);
+		BC.CreateBr(MergeBB);
+		SW->addCase(B.getInt32(Case), CBB);
+		};
+
+	addCase(BS_SUB, "sub", [&](IRBuilder<>& BC) { return BC.CreateSub(AArg, BArg, "sub"); });
+	addCase(BS_MUL, "mul", [&](IRBuilder<>& BC) { return BC.CreateMul(AArg, BArg, "mul"); });
+	addCase(BS_AND, "and", [&](IRBuilder<>& BC) { return BC.CreateAnd(AArg, BArg, "and"); });
+	addCase(BS_OR, "or", [&](IRBuilder<>& BC) { return BC.CreateOr(AArg, BArg, "or"); });
+	addCase(BS_XOR, "xor", [&](IRBuilder<>& BC) { return BC.CreateXor(AArg, BArg, "xor"); });
+	addCase(BS_SHL, "shl", [&](IRBuilder<>& BC) { return BC.CreateShl(AArg, BArg, "shl"); });
+	addCase(BS_LSHR, "lshr", [&](IRBuilder<>& BC) { return BC.CreateLShr(AArg, BArg, "lshr"); });
+	addCase(BS_ASHR, "ashr", [&](IRBuilder<>& BC) { return BC.CreateAShr(AArg, BArg, "ashr"); });
+	addCase(BS_SDIV, "sdiv", [&](IRBuilder<>& BC) { return BC.CreateSDiv(AArg, BArg, "sdiv"); });
+	addCase(BS_UDIV, "udiv", [&](IRBuilder<>& BC) { return BC.CreateUDiv(AArg, BArg, "udiv"); });
+	addCase(BS_SREM, "srem", [&](IRBuilder<>& BC) { return BC.CreateSRem(AArg, BArg, "srem"); });
+	addCase(BS_UREM, "urem", [&](IRBuilder<>& BC) { return BC.CreateURem(AArg, BArg, "urem"); });
+
+	return HF;
+}
+
+// Pure helper `i32 __vm_h_icmp(i32 a, i32 b, i8 pred)` -- replicates OP_ICMP's
+// predicate select-chain (buildHandlersIntArith) as a switch. `pred` is the
+// raw CmpInst::Predicate byte (ICMP_EQ..ICMP_SLE). Default (pred matches none
+// of the 10 integer predicates) returns 0, matching the select chain's
+// initial R=false.
+Function* VMImpl::getOrCreateNestedIcmpHelper() {
+	if (Function* Existing = M.getFunction(kNestedIcmpHelperName))
+		return Existing;
+
+	FunctionType* FTy = FunctionType::get(I32Ty, { I32Ty, I32Ty, I8Ty }, false);
+	Function* HF = Function::Create(FTy, GlobalValue::InternalLinkage,
+		kNestedIcmpHelperName, &M);
+	HF->addFnAttr(Attribute::NoUnwind);
+	Argument* AArg = HF->getArg(0); AArg->setName("a");
+	Argument* BArg = HF->getArg(1); BArg->setName("b");
+	Argument* PredArg = HF->getArg(2); PredArg->setName("pred");
+
+	BasicBlock* EntryBB = BasicBlock::Create(Ctx, "entry", HF);
+	IRBuilder<> B(EntryBB);
+	Value* Pred32 = B.CreateZExt(PredArg, I32Ty, "pred32");
+
+	BasicBlock* MergeBB = BasicBlock::Create(Ctx, "merge", HF);
+	BasicBlock* DefBB = BasicBlock::Create(Ctx, "def", HF);
+	SwitchInst* SW = B.CreateSwitch(Pred32, DefBB, 10);
+
+	IRBuilder<> BM(MergeBB);
+	auto* Phi = BM.CreatePHI(I32Ty, 11, "r");
+	BM.CreateRet(Phi);
+
+	{
+		// Default: pred matches none of the 10 -- result 0 (matches OP_ICMP's
+		// initial R=false).
+		IRBuilder<> BD(DefBB);
+		Phi->addIncoming(BD.getInt32(0), DefBB);
+		BD.CreateBr(MergeBB);
+	}
+
+	using P = CmpInst::Predicate;
+	auto addCase = [&](P Pred, const Twine& Name, auto Emit) {
+		BasicBlock* CBB = BasicBlock::Create(Ctx, Name, HF);
+		IRBuilder<> BC(CBB);
+		Value* Rv = BC.CreateZExt(Emit(BC), I32Ty, "z");
+		Phi->addIncoming(Rv, CBB);
+		BC.CreateBr(MergeBB);
+		SW->addCase(B.getInt32((uint32_t)Pred), CBB);
+		};
+
+	addCase(P::ICMP_EQ, "eq", [&](IRBuilder<>& BC) { return BC.CreateICmpEQ(AArg, BArg); });
+	addCase(P::ICMP_NE, "ne", [&](IRBuilder<>& BC) { return BC.CreateICmpNE(AArg, BArg); });
+	addCase(P::ICMP_UGT, "ugt", [&](IRBuilder<>& BC) { return BC.CreateICmpUGT(AArg, BArg); });
+	addCase(P::ICMP_UGE, "uge", [&](IRBuilder<>& BC) { return BC.CreateICmpUGE(AArg, BArg); });
+	addCase(P::ICMP_ULT, "ult", [&](IRBuilder<>& BC) { return BC.CreateICmpULT(AArg, BArg); });
+	addCase(P::ICMP_ULE, "ule", [&](IRBuilder<>& BC) { return BC.CreateICmpULE(AArg, BArg); });
+	addCase(P::ICMP_SGT, "sgt", [&](IRBuilder<>& BC) { return BC.CreateICmpSGT(AArg, BArg); });
+	addCase(P::ICMP_SGE, "sge", [&](IRBuilder<>& BC) { return BC.CreateICmpSGE(AArg, BArg); });
+	addCase(P::ICMP_SLT, "slt", [&](IRBuilder<>& BC) { return BC.CreateICmpSLT(AArg, BArg); });
+	addCase(P::ICMP_SLE, "sle", [&](IRBuilder<>& BC) { return BC.CreateICmpSLE(AArg, BArg); });
+
+	return HF;
+}
+
+// Pure helper `i32 __vm_h_icmp64(i64 a, i64 b, i8 pred)` -- replicates
+// OP_ICMP64's predicate select-chain, same shape as getOrCreateNestedIcmpHelper()
+// but over I64Ty operands (result stays i32, matching OP_ICMP64's vreg dest).
+Function* VMImpl::getOrCreateNestedIcmp64Helper() {
+	if (Function* Existing = M.getFunction(kNestedIcmp64HelperName))
+		return Existing;
+
+	FunctionType* FTy = FunctionType::get(I32Ty, { I64Ty, I64Ty, I8Ty }, false);
+	Function* HF = Function::Create(FTy, GlobalValue::InternalLinkage,
+		kNestedIcmp64HelperName, &M);
+	HF->addFnAttr(Attribute::NoUnwind);
+	Argument* AArg = HF->getArg(0); AArg->setName("a");
+	Argument* BArg = HF->getArg(1); BArg->setName("b");
+	Argument* PredArg = HF->getArg(2); PredArg->setName("pred");
+
+	BasicBlock* EntryBB = BasicBlock::Create(Ctx, "entry", HF);
+	IRBuilder<> B(EntryBB);
+	Value* Pred32 = B.CreateZExt(PredArg, I32Ty, "pred32");
+
+	BasicBlock* MergeBB = BasicBlock::Create(Ctx, "merge", HF);
+	BasicBlock* DefBB = BasicBlock::Create(Ctx, "def", HF);
+	SwitchInst* SW = B.CreateSwitch(Pred32, DefBB, 10);
+
+	IRBuilder<> BM(MergeBB);
+	auto* Phi = BM.CreatePHI(I32Ty, 11, "r");
+	BM.CreateRet(Phi);
+
+	{
+		// Default: pred matches none of the 10 -- result 0 (matches OP_ICMP64's
+		// initial R=false).
+		IRBuilder<> BD(DefBB);
+		Phi->addIncoming(BD.getInt32(0), DefBB);
+		BD.CreateBr(MergeBB);
+	}
+
+	using P = CmpInst::Predicate;
+	auto addCase = [&](P Pred, const Twine& Name, auto Emit) {
+		BasicBlock* CBB = BasicBlock::Create(Ctx, Name, HF);
+		IRBuilder<> BC(CBB);
+		Value* Rv = BC.CreateZExt(Emit(BC), I32Ty, "z");
+		Phi->addIncoming(Rv, CBB);
+		BC.CreateBr(MergeBB);
+		SW->addCase(B.getInt32((uint32_t)Pred), CBB);
+		};
+
+	addCase(P::ICMP_EQ, "eq", [&](IRBuilder<>& BC) { return BC.CreateICmpEQ(AArg, BArg); });
+	addCase(P::ICMP_NE, "ne", [&](IRBuilder<>& BC) { return BC.CreateICmpNE(AArg, BArg); });
+	addCase(P::ICMP_UGT, "ugt", [&](IRBuilder<>& BC) { return BC.CreateICmpUGT(AArg, BArg); });
+	addCase(P::ICMP_UGE, "uge", [&](IRBuilder<>& BC) { return BC.CreateICmpUGE(AArg, BArg); });
+	addCase(P::ICMP_ULT, "ult", [&](IRBuilder<>& BC) { return BC.CreateICmpULT(AArg, BArg); });
+	addCase(P::ICMP_ULE, "ule", [&](IRBuilder<>& BC) { return BC.CreateICmpULE(AArg, BArg); });
+	addCase(P::ICMP_SGT, "sgt", [&](IRBuilder<>& BC) { return BC.CreateICmpSGT(AArg, BArg); });
+	addCase(P::ICMP_SGE, "sge", [&](IRBuilder<>& BC) { return BC.CreateICmpSGE(AArg, BArg); });
+	addCase(P::ICMP_SLT, "slt", [&](IRBuilder<>& BC) { return BC.CreateICmpSLT(AArg, BArg); });
+	addCase(P::ICMP_SLE, "sle", [&](IRBuilder<>& BC) { return BC.CreateICmpSLE(AArg, BArg); });
+
+	return HF;
+}
+
+// Pure helper `i32 __vm_h_fcmp(double a, double b, i8 pred)` -- replicates
+// OP_FCMP's predicate switch (buildHandlersFloat) exactly. `pred` is the raw
+// CmpInst::Predicate byte (FCMP_OEQ..FCMP_UNO). Default -- FCMP_FALSE
+// (pred=0), and any unmatched pred value (e.g. FCMP_TRUE) -- returns 0,
+// matching OP_FCMP's default block exactly (including its FCMP_TRUE gap).
+Function* VMImpl::getOrCreateNestedFcmpHelper() {
+	if (Function* Existing = M.getFunction(kNestedFcmpHelperName))
+		return Existing;
+
+	FunctionType* FTy = FunctionType::get(I32Ty, { DoubleTy, DoubleTy, I8Ty }, false);
+	Function* HF = Function::Create(FTy, GlobalValue::InternalLinkage,
+		kNestedFcmpHelperName, &M);
+	HF->addFnAttr(Attribute::NoUnwind);
+	Argument* AArg = HF->getArg(0); AArg->setName("a");
+	Argument* BArg = HF->getArg(1); BArg->setName("b");
+	Argument* PredArg = HF->getArg(2); PredArg->setName("pred");
+
+	BasicBlock* EntryBB = BasicBlock::Create(Ctx, "entry", HF);
+	IRBuilder<> B(EntryBB);
+	Value* Pred32 = B.CreateZExt(PredArg, I32Ty, "pred32");
+
+	BasicBlock* MergeBB = BasicBlock::Create(Ctx, "merge", HF);
+	BasicBlock* DefBB = BasicBlock::Create(Ctx, "def", HF);
+	SwitchInst* SW = B.CreateSwitch(Pred32, DefBB, 14);
+
+	IRBuilder<> BM(MergeBB);
+	auto* Phi = BM.CreatePHI(I32Ty, 15, "r");
+	BM.CreateRet(Phi);
+
+	{
+		IRBuilder<> BD(DefBB);
+		Phi->addIncoming(BD.getInt32(0), DefBB);
+		BD.CreateBr(MergeBB);
+	}
+
+	using FP = CmpInst::Predicate;
+	auto addCase = [&](FP Pred, const Twine& Name, auto Emit) {
+		BasicBlock* CBB = BasicBlock::Create(Ctx, Name, HF);
+		IRBuilder<> BC(CBB);
+		Value* Rv = BC.CreateZExt(Emit(BC), I32Ty, "z");
+		Phi->addIncoming(Rv, CBB);
+		BC.CreateBr(MergeBB);
+		SW->addCase(B.getInt32((uint32_t)Pred), CBB);
+		};
+
+	addCase(FP::FCMP_OEQ, "oeq", [&](IRBuilder<>& BC) { return BC.CreateFCmpOEQ(AArg, BArg); });
+	addCase(FP::FCMP_OGT, "ogt", [&](IRBuilder<>& BC) { return BC.CreateFCmpOGT(AArg, BArg); });
+	addCase(FP::FCMP_OGE, "oge", [&](IRBuilder<>& BC) { return BC.CreateFCmpOGE(AArg, BArg); });
+	addCase(FP::FCMP_OLT, "olt", [&](IRBuilder<>& BC) { return BC.CreateFCmpOLT(AArg, BArg); });
+	addCase(FP::FCMP_OLE, "ole", [&](IRBuilder<>& BC) { return BC.CreateFCmpOLE(AArg, BArg); });
+	addCase(FP::FCMP_ONE, "one", [&](IRBuilder<>& BC) { return BC.CreateFCmpONE(AArg, BArg); });
+	addCase(FP::FCMP_ORD, "ord", [&](IRBuilder<>& BC) { return BC.CreateFCmpORD(AArg, BArg); });
+	addCase(FP::FCMP_UEQ, "ueq", [&](IRBuilder<>& BC) { return BC.CreateFCmpUEQ(AArg, BArg); });
+	addCase(FP::FCMP_UGT, "ugt", [&](IRBuilder<>& BC) { return BC.CreateFCmpUGT(AArg, BArg); });
+	addCase(FP::FCMP_UGE, "uge", [&](IRBuilder<>& BC) { return BC.CreateFCmpUGE(AArg, BArg); });
+	addCase(FP::FCMP_ULT, "ult", [&](IRBuilder<>& BC) { return BC.CreateFCmpULT(AArg, BArg); });
+	addCase(FP::FCMP_ULE, "ule", [&](IRBuilder<>& BC) { return BC.CreateFCmpULE(AArg, BArg); });
+	addCase(FP::FCMP_UNE, "une", [&](IRBuilder<>& BC) { return BC.CreateFCmpUNE(AArg, BArg); });
+	addCase(FP::FCMP_UNO, "uno", [&](IRBuilder<>& BC) { return BC.CreateFCmpUNO(AArg, BArg); });
+
+	return HF;
+}
+
+// Pure helper `i32 __vm_h_cast(i32 src, i8 kind)` -- replicates OP_CAST's
+// kind select-chain (buildHandlersIntArith) as a switch. `kind` 0..7 covers
+// CK_ZEXT1/8/16, CK_SEXT8/16, CK_TRUNC1/8/16 -- all operate within the i32
+// reg file, so zextN and truncN of an already-i32 value share the same
+// AND/shift body (mirroring OP_CAST's Cvs[] table, which reuses ze() for both
+// the ZEXT and TRUNC cases). Default (kind not in 0..7) returns src
+// unchanged, matching the select chain's initial R=SV.
+Function* VMImpl::getOrCreateNestedCastHelper() {
+	if (Function* Existing = M.getFunction(kNestedCastHelperName))
+		return Existing;
+
+	FunctionType* FTy = FunctionType::get(I32Ty, { I32Ty, I8Ty }, false);
+	Function* HF = Function::Create(FTy, GlobalValue::InternalLinkage,
+		kNestedCastHelperName, &M);
+	HF->addFnAttr(Attribute::NoUnwind);
+	Argument* SrcArg = HF->getArg(0); SrcArg->setName("src");
+	Argument* KindArg = HF->getArg(1); KindArg->setName("kind");
+
+	BasicBlock* EntryBB = BasicBlock::Create(Ctx, "entry", HF);
+	IRBuilder<> B(EntryBB);
+	Value* Kind32 = B.CreateZExt(KindArg, I32Ty, "kind32");
+
+	BasicBlock* MergeBB = BasicBlock::Create(Ctx, "merge", HF);
+	BasicBlock* DefBB = BasicBlock::Create(Ctx, "def", HF);
+	SwitchInst* SW = B.CreateSwitch(Kind32, DefBB, 8);
+
+	IRBuilder<> BM(MergeBB);
+	auto* Phi = BM.CreatePHI(I32Ty, 9, "r");
+	BM.CreateRet(Phi);
+
+	{
+		// Default: kind not in 0..7 -- result is src unchanged.
+		IRBuilder<> BD(DefBB);
+		Phi->addIncoming(SrcArg, DefBB);
+		BD.CreateBr(MergeBB);
+	}
+
+	auto addCase = [&](uint32_t Case, const Twine& Name, auto Emit) {
+		BasicBlock* CBB = BasicBlock::Create(Ctx, Name, HF);
+		IRBuilder<> BC(CBB);
+		Value* Rv = Emit(BC);
+		Phi->addIncoming(Rv, CBB);
+		BC.CreateBr(MergeBB);
+		SW->addCase(B.getInt32(Case), CBB);
+		};
+
+	auto ze = [&](IRBuilder<>& BC, uint32_t Mask) -> Value* {
+		return BC.CreateAnd(SrcArg, BC.getInt32(Mask), "ze"); };
+	auto se = [&](IRBuilder<>& BC, uint32_t W) -> Value* {
+		return BC.CreateAShr(BC.CreateShl(SrcArg, BC.getInt32(32 - W), "ssl"),
+			BC.getInt32(32 - W), "ssr");
+		};
+
+	addCase(CK_ZEXT1, "zext1", [&](IRBuilder<>& BC) { return ze(BC, 1); });
+	addCase(CK_ZEXT8, "zext8", [&](IRBuilder<>& BC) { return ze(BC, 0xFF); });
+	addCase(CK_ZEXT16, "zext16", [&](IRBuilder<>& BC) { return ze(BC, 0xFFFF); });
+	addCase(CK_SEXT8, "sext8", [&](IRBuilder<>& BC) { return se(BC, 8); });
+	addCase(CK_SEXT16, "sext16", [&](IRBuilder<>& BC) { return se(BC, 16); });
+	addCase(CK_TRUNC1, "trunc1", [&](IRBuilder<>& BC) { return ze(BC, 1); });
+	addCase(CK_TRUNC8, "trunc8", [&](IRBuilder<>& BC) { return ze(BC, 0xFF); });
+	addCase(CK_TRUNC16, "trunc16", [&](IRBuilder<>& BC) { return ze(BC, 0xFFFF); });
+
+	return HF;
+}
+
+// Inner-virtualize every created pure helper, exactly once per module. Must
+// run AFTER populateVMEngine() -- see the sequencing note above. Loops over
+// the fixed nesting order; a helper not found by name was never referenced
+// (opcodeNests() excluded it, e.g. via the nestedVMOpcodes cap).
+void VMImpl::virtualizeNestedHelpersOnce() {
+	VMEngine::SharedState* SS = VMEngine::getSharedState(M, EngineId);
+	if (SS->NestedHelpersBuilt) return;
+	SS->NestedHelpersBuilt = true;
+
+	VMPassConfig InnerCfg = Cfg;
+	InnerCfg.nestedVM = false; // hard recursion guard: no helper is ever itself nested
+	InnerCfg.minBlocks = 1;    // helper is a single small switch
+
+	for (unsigned i = 0; i < kNumNestedHelpers; ++i) {
+		Function* HelperFn = M.getFunction(kNestedHelperOrder[i].Name);
+		if (!HelperFn) continue; // this opcode's helper was never referenced
+
+		obf::Rng InnerRng = R.fork((Twine("vm.nested.inner.") + kNestedHelperOrder[i].Name).str());
+		VMImpl Inner(*HelperFn, InnerCfg, InnerRng);
+		if (!Inner.run()) {
+			LLVM_DEBUG(dbgs() << "[vm] nested-VM: failed to virtualize '"
+				<< HelperFn->getName() << "': " << Inner.FailReason << "\n");
+			if (ObfVerbose)
+				errs() << "[vm] nested-VM: failed to virtualize '" << HelperFn->getName()
+				<< "': " << Inner.FailReason << "\n";
+		}
+	}
+}
+
 void VMImpl::buildOpcodeHandlers() {
 	for (unsigned v = 0; v < NumVariants; ++v) {
 		CurVariant = v;
@@ -470,46 +961,58 @@ void VMImpl::buildHandlersIntArith() {
 		Value* AV = ldVR(B, AIdx);
 		Value* BV = ldVR(B, BIdx);
 
-		BasicBlock* MergeBB = BasicBlock::Create(Ctx, "vm.bo.merge", HFn);
-		BasicBlock* DefBB = BasicBlock::Create(Ctx, "vm.bo.def", HFn);
+		if (NestedVM) {
+			// Compute via a call into the pure helper, itself separately
+			// inner-virtualized (see virtualizeNestedHelpersOnce()), instead
+			// of the inline switch below. Decode/load stay identical to the
+			// non-nested path; only the compute step differs.
+			Function* HelperFn = M.getFunction(kNestedBinopHelperName);
+			Value* Sub8 = B.CreateTrunc(Sub, I8Ty, "vm.bo.sub8");
+			Value* Rv = B.CreateCall(HelperFn, { AV, BV, Sub8 }, "vm.bo.nested");
+			stVR(B, Dst, Rv);
+			B.CreateBr(Dispatch);
+		} else {
+			BasicBlock* MergeBB = BasicBlock::Create(Ctx, "vm.bo.merge", HFn);
+			BasicBlock* DefBB = BasicBlock::Create(Ctx, "vm.bo.def", HFn);
 
 
-		// Default implements BS_ADD (matches previous select-chain fallback)
-		SwitchInst* SW = B.CreateSwitch(Sub, DefBB, 12);
+			// Default implements BS_ADD (matches previous select-chain fallback)
+			SwitchInst* SW = B.CreateSwitch(Sub, DefBB, 12);
 
-		IRBuilder<> BM(MergeBB);
-		auto* Phi = BM.CreatePHI(I32Ty, 13, "vm.bo.r");
-		stVR(BM, Dst, Phi);
-		BM.CreateBr(Dispatch);
+			IRBuilder<> BM(MergeBB);
+			auto* Phi = BM.CreatePHI(I32Ty, 13, "vm.bo.r");
+			stVR(BM, Dst, Phi);
+			BM.CreateBr(Dispatch);
 
-		{
-			IRBuilder<> BD(DefBB);
-			Value* R = BD.CreateAdd(AV, BV, "vm.add");
-			Phi->addIncoming(R, DefBB);
-			BD.CreateBr(MergeBB);
+			{
+				IRBuilder<> BD(DefBB);
+				Value* R = BD.CreateAdd(AV, BV, "vm.add");
+				Phi->addIncoming(R, DefBB);
+				BD.CreateBr(MergeBB);
+			}
+
+			auto addCase = [&](uint32_t Case, const Twine& BBName, auto Emit) {
+				BasicBlock* CBB = BasicBlock::Create(Ctx, BBName, HFn);
+				IRBuilder<> BC(CBB);
+				Value* R = Emit(BC);
+				Phi->addIncoming(R, CBB);
+				BC.CreateBr(MergeBB);
+				SW->addCase(B.getInt32(Case), CBB);
+				};
+
+			addCase(BS_SUB, "vm.bo.sub", [&](IRBuilder<>& BC) { return BC.CreateSub(AV, BV, "vm.sub"); });
+			addCase(BS_MUL, "vm.bo.mul", [&](IRBuilder<>& BC) { return BC.CreateMul(AV, BV, "vm.mul"); });
+			addCase(BS_AND, "vm.bo.and", [&](IRBuilder<>& BC) { return BC.CreateAnd(AV, BV, "vm.and"); });
+			addCase(BS_OR, "vm.bo.or", [&](IRBuilder<>& BC) { return BC.CreateOr(AV, BV, "vm.or"); });
+			addCase(BS_XOR, "vm.bo.xor", [&](IRBuilder<>& BC) { return BC.CreateXor(AV, BV, "vm.xor"); });
+			addCase(BS_SHL, "vm.bo.shl", [&](IRBuilder<>& BC) { return BC.CreateShl(AV, BV, "vm.shl"); });
+			addCase(BS_LSHR, "vm.bo.lshr", [&](IRBuilder<>& BC) { return BC.CreateLShr(AV, BV, "vm.lshr"); });
+			addCase(BS_ASHR, "vm.bo.ashr", [&](IRBuilder<>& BC) { return BC.CreateAShr(AV, BV, "vm.ashr"); });
+			addCase(BS_SDIV, "vm.bo.sdiv", [&](IRBuilder<>& BC) { return BC.CreateSDiv(AV, BV, "vm.sdiv"); });
+			addCase(BS_UDIV, "vm.bo.udiv", [&](IRBuilder<>& BC) { return BC.CreateUDiv(AV, BV, "vm.udiv"); });
+			addCase(BS_SREM, "vm.bo.srem", [&](IRBuilder<>& BC) { return BC.CreateSRem(AV, BV, "vm.srem"); });
+			addCase(BS_UREM, "vm.bo.urem", [&](IRBuilder<>& BC) { return BC.CreateURem(AV, BV, "vm.urem"); });
 		}
-
-		auto addCase = [&](uint32_t Case, const Twine& BBName, auto Emit) {
-			BasicBlock* CBB = BasicBlock::Create(Ctx, BBName, HFn);
-			IRBuilder<> BC(CBB);
-			Value* R = Emit(BC);
-			Phi->addIncoming(R, CBB);
-			BC.CreateBr(MergeBB);
-			SW->addCase(B.getInt32(Case), CBB);
-			};
-
-		addCase(BS_SUB, "vm.bo.sub", [&](IRBuilder<>& BC) { return BC.CreateSub(AV, BV, "vm.sub"); });
-		addCase(BS_MUL, "vm.bo.mul", [&](IRBuilder<>& BC) { return BC.CreateMul(AV, BV, "vm.mul"); });
-		addCase(BS_AND, "vm.bo.and", [&](IRBuilder<>& BC) { return BC.CreateAnd(AV, BV, "vm.and"); });
-		addCase(BS_OR, "vm.bo.or", [&](IRBuilder<>& BC) { return BC.CreateOr(AV, BV, "vm.or"); });
-		addCase(BS_XOR, "vm.bo.xor", [&](IRBuilder<>& BC) { return BC.CreateXor(AV, BV, "vm.xor"); });
-		addCase(BS_SHL, "vm.bo.shl", [&](IRBuilder<>& BC) { return BC.CreateShl(AV, BV, "vm.shl"); });
-		addCase(BS_LSHR, "vm.bo.lshr", [&](IRBuilder<>& BC) { return BC.CreateLShr(AV, BV, "vm.lshr"); });
-		addCase(BS_ASHR, "vm.bo.ashr", [&](IRBuilder<>& BC) { return BC.CreateAShr(AV, BV, "vm.ashr"); });
-		addCase(BS_SDIV, "vm.bo.sdiv", [&](IRBuilder<>& BC) { return BC.CreateSDiv(AV, BV, "vm.sdiv"); });
-		addCase(BS_UDIV, "vm.bo.udiv", [&](IRBuilder<>& BC) { return BC.CreateUDiv(AV, BV, "vm.udiv"); });
-		addCase(BS_SREM, "vm.bo.srem", [&](IRBuilder<>& BC) { return BC.CreateSRem(AV, BV, "vm.srem"); });
-		addCase(BS_UREM, "vm.bo.urem", [&](IRBuilder<>& BC) { return BC.CreateURem(AV, BV, "vm.urem"); });
 	}
 
 
@@ -525,45 +1028,55 @@ void VMImpl::buildHandlersIntArith() {
 		Value* AV = ldVR64(B, AIdx);
 		Value* BV = ldVR64(B, BIdx);
 
-		BasicBlock* MergeBB = BasicBlock::Create(Ctx, "vm.bo64.merge", HFn);
-		BasicBlock* DefBB = BasicBlock::Create(Ctx, "vm.bo64.def", HFn);
+		if (NestedVM && opcodeNests(OP_BINOP64)) {
+			// See OP_BINOP's NestedVM branch: decode/load stay identical to
+			// the inline path below, only the compute step calls the helper.
+			Function* HelperFn = M.getFunction(kNestedBinop64HelperName);
+			Value* Sub8 = B.CreateTrunc(Sub, I8Ty, "vm.bo64.sub8");
+			Value* Rv = B.CreateCall(HelperFn, { AV, BV, Sub8 }, "vm.bo64.nested");
+			stVR64(B, Dst, Rv);
+			B.CreateBr(Dispatch);
+		} else {
+			BasicBlock* MergeBB = BasicBlock::Create(Ctx, "vm.bo64.merge", HFn);
+			BasicBlock* DefBB = BasicBlock::Create(Ctx, "vm.bo64.def", HFn);
 
-		// Default implements BS_ADD (matches previous select-chain fallback)
-		SwitchInst* SW = B.CreateSwitch(Sub, DefBB, 12);
+			// Default implements BS_ADD (matches previous select-chain fallback)
+			SwitchInst* SW = B.CreateSwitch(Sub, DefBB, 12);
 
-		IRBuilder<> BM(MergeBB);
-		auto* Phi = BM.CreatePHI(I64Ty, 13, "vm.bo64.r");
-		stVR64(BM, Dst, Phi);
-		BM.CreateBr(Dispatch);
+			IRBuilder<> BM(MergeBB);
+			auto* Phi = BM.CreatePHI(I64Ty, 13, "vm.bo64.r");
+			stVR64(BM, Dst, Phi);
+			BM.CreateBr(Dispatch);
 
-		{
-			IRBuilder<> BD(DefBB);
-			Value* R = BD.CreateAdd(AV, BV, "vm64.add");
-			Phi->addIncoming(R, DefBB);
-			BD.CreateBr(MergeBB);
+			{
+				IRBuilder<> BD(DefBB);
+				Value* R = BD.CreateAdd(AV, BV, "vm64.add");
+				Phi->addIncoming(R, DefBB);
+				BD.CreateBr(MergeBB);
+			}
+
+			auto addCase = [&](uint32_t Case, const Twine& BBName, auto Emit) {
+				BasicBlock* CBB = BasicBlock::Create(Ctx, BBName, HFn);
+				IRBuilder<> BC(CBB);
+				Value* R = Emit(BC);
+				Phi->addIncoming(R, CBB);
+				BC.CreateBr(MergeBB);
+				SW->addCase(B.getInt32(Case), CBB);
+				};
+
+			addCase(BS_SUB, "vm.bo64.sub", [&](IRBuilder<>& BC) { return BC.CreateSub(AV, BV, "vm64.sub"); });
+			addCase(BS_MUL, "vm.bo64.mul", [&](IRBuilder<>& BC) { return BC.CreateMul(AV, BV, "vm64.mul"); });
+			addCase(BS_AND, "vm.bo64.and", [&](IRBuilder<>& BC) { return BC.CreateAnd(AV, BV, "vm64.and"); });
+			addCase(BS_OR, "vm.bo64.or", [&](IRBuilder<>& BC) { return BC.CreateOr(AV, BV, "vm64.or"); });
+			addCase(BS_XOR, "vm.bo64.xor", [&](IRBuilder<>& BC) { return BC.CreateXor(AV, BV, "vm64.xor"); });
+			addCase(BS_SHL, "vm.bo64.shl", [&](IRBuilder<>& BC) { return BC.CreateShl(AV, BV, "vm64.shl"); });
+			addCase(BS_LSHR, "vm.bo64.lshr", [&](IRBuilder<>& BC) { return BC.CreateLShr(AV, BV, "vm64.lshr"); });
+			addCase(BS_ASHR, "vm.bo64.ashr", [&](IRBuilder<>& BC) { return BC.CreateAShr(AV, BV, "vm64.ashr"); });
+			addCase(BS_SDIV, "vm.bo64.sdiv", [&](IRBuilder<>& BC) { return BC.CreateSDiv(AV, BV, "vm64.sdiv"); });
+			addCase(BS_UDIV, "vm.bo64.udiv", [&](IRBuilder<>& BC) { return BC.CreateUDiv(AV, BV, "vm64.udiv"); });
+			addCase(BS_SREM, "vm.bo64.srem", [&](IRBuilder<>& BC) { return BC.CreateSRem(AV, BV, "vm64.srem"); });
+			addCase(BS_UREM, "vm.bo64.urem", [&](IRBuilder<>& BC) { return BC.CreateURem(AV, BV, "vm64.urem"); });
 		}
-
-		auto addCase = [&](uint32_t Case, const Twine& BBName, auto Emit) {
-			BasicBlock* CBB = BasicBlock::Create(Ctx, BBName, HFn);
-			IRBuilder<> BC(CBB);
-			Value* R = Emit(BC);
-			Phi->addIncoming(R, CBB);
-			BC.CreateBr(MergeBB);
-			SW->addCase(B.getInt32(Case), CBB);
-			};
-
-		addCase(BS_SUB, "vm.bo64.sub", [&](IRBuilder<>& BC) { return BC.CreateSub(AV, BV, "vm64.sub"); });
-		addCase(BS_MUL, "vm.bo64.mul", [&](IRBuilder<>& BC) { return BC.CreateMul(AV, BV, "vm64.mul"); });
-		addCase(BS_AND, "vm.bo64.and", [&](IRBuilder<>& BC) { return BC.CreateAnd(AV, BV, "vm64.and"); });
-		addCase(BS_OR, "vm.bo64.or", [&](IRBuilder<>& BC) { return BC.CreateOr(AV, BV, "vm64.or"); });
-		addCase(BS_XOR, "vm.bo64.xor", [&](IRBuilder<>& BC) { return BC.CreateXor(AV, BV, "vm64.xor"); });
-		addCase(BS_SHL, "vm.bo64.shl", [&](IRBuilder<>& BC) { return BC.CreateShl(AV, BV, "vm64.shl"); });
-		addCase(BS_LSHR, "vm.bo64.lshr", [&](IRBuilder<>& BC) { return BC.CreateLShr(AV, BV, "vm64.lshr"); });
-		addCase(BS_ASHR, "vm.bo64.ashr", [&](IRBuilder<>& BC) { return BC.CreateAShr(AV, BV, "vm64.ashr"); });
-		addCase(BS_SDIV, "vm.bo64.sdiv", [&](IRBuilder<>& BC) { return BC.CreateSDiv(AV, BV, "vm64.sdiv"); });
-		addCase(BS_UDIV, "vm.bo64.udiv", [&](IRBuilder<>& BC) { return BC.CreateUDiv(AV, BV, "vm64.udiv"); });
-		addCase(BS_SREM, "vm.bo64.srem", [&](IRBuilder<>& BC) { return BC.CreateSRem(AV, BV, "vm64.srem"); });
-		addCase(BS_UREM, "vm.bo64.urem", [&](IRBuilder<>& BC) { return BC.CreateURem(AV, BV, "vm64.urem"); });
 	}
 	//  OP_ICMP -- [dst:u8 a:u8 b:u8 pred:u8] 
 	{
@@ -572,20 +1085,29 @@ void VMImpl::buildHandlersIntArith() {
 		Value* Dst = rdVR(B, IP, 0, "vm.ic.d"), * AIdx = rdVR(B, IP, 1, "vm.ic.a");
 		Value* BIdx = rdVR(B, IP, 2, "vm.ic.b"), * Pred = rdByte(B, IP, 3, "vm.ic.p");
 		Value* AV = ldVR(B, AIdx), * BV = ldVR(B, BIdx);
-		using P = CmpInst::Predicate;
-		Value* Cs[] = {
-		  B.CreateICmpEQ(AV,BV), B.CreateICmpNE(AV,BV),
-		  B.CreateICmpUGT(AV,BV), B.CreateICmpUGE(AV,BV),
-		  B.CreateICmpULT(AV,BV), B.CreateICmpULE(AV,BV),
-		  B.CreateICmpSGT(AV,BV), B.CreateICmpSGE(AV,BV),
-		  B.CreateICmpSLT(AV,BV), B.CreateICmpSLE(AV,BV),
-		};
-		P Ps[] = { P::ICMP_EQ,P::ICMP_NE,P::ICMP_UGT,P::ICMP_UGE,P::ICMP_ULT,
-				P::ICMP_ULE,P::ICMP_SGT,P::ICMP_SGE,P::ICMP_SLT,P::ICMP_SLE };
-		Value* R = B.getInt1(false);
-		for (unsigned i = 0; i < 10; i++)
-			R = B.CreateSelect(B.CreateICmpEQ(Pred, B.getInt32((uint32_t)Ps[i])), Cs[i], R);
-		stVR(B, Dst, B.CreateZExt(R, I32Ty, "vm.ic.r")); B.CreateBr(Dispatch);
+
+		if (NestedVM && opcodeNests(OP_ICMP)) {
+			Function* HelperFn = M.getFunction(kNestedIcmpHelperName);
+			Value* Pred8 = B.CreateTrunc(Pred, I8Ty, "vm.ic.pred8");
+			Value* Rv = B.CreateCall(HelperFn, { AV, BV, Pred8 }, "vm.ic.nested");
+			stVR(B, Dst, Rv);
+			B.CreateBr(Dispatch);
+		} else {
+			using P = CmpInst::Predicate;
+			Value* Cs[] = {
+			  B.CreateICmpEQ(AV,BV), B.CreateICmpNE(AV,BV),
+			  B.CreateICmpUGT(AV,BV), B.CreateICmpUGE(AV,BV),
+			  B.CreateICmpULT(AV,BV), B.CreateICmpULE(AV,BV),
+			  B.CreateICmpSGT(AV,BV), B.CreateICmpSGE(AV,BV),
+			  B.CreateICmpSLT(AV,BV), B.CreateICmpSLE(AV,BV),
+			};
+			P Ps[] = { P::ICMP_EQ,P::ICMP_NE,P::ICMP_UGT,P::ICMP_UGE,P::ICMP_ULT,
+					P::ICMP_ULE,P::ICMP_SGT,P::ICMP_SGE,P::ICMP_SLT,P::ICMP_SLE };
+			Value* R = B.getInt1(false);
+			for (unsigned i = 0; i < 10; i++)
+				R = B.CreateSelect(B.CreateICmpEQ(Pred, B.getInt32((uint32_t)Ps[i])), Cs[i], R);
+			stVR(B, Dst, B.CreateZExt(R, I32Ty, "vm.ic.r")); B.CreateBr(Dispatch);
+		}
 	}
 
 
@@ -603,23 +1125,31 @@ void VMImpl::buildHandlersIntArith() {
 		Value* Pred = rdByte(B, IP, 3, "vm.ic64.p");
 		Value* AV = ldVR64(B, AIdx), * BV = ldVR64(B, BIdx);
 
-		using P = CmpInst::Predicate;
-		Value* Cs[] = {
-		  B.CreateICmpEQ(AV,BV), B.CreateICmpNE(AV,BV),
-		  B.CreateICmpUGT(AV,BV), B.CreateICmpUGE(AV,BV),
-		  B.CreateICmpULT(AV,BV), B.CreateICmpULE(AV,BV),
-		  B.CreateICmpSGT(AV,BV), B.CreateICmpSGE(AV,BV),
-		  B.CreateICmpSLT(AV,BV), B.CreateICmpSLE(AV,BV),
-		};
-		P Ps[] = { P::ICMP_EQ,P::ICMP_NE,P::ICMP_UGT,P::ICMP_UGE,P::ICMP_ULT,
-				   P::ICMP_ULE,P::ICMP_SGT,P::ICMP_SGE,P::ICMP_SLT,P::ICMP_SLE };
+		if (NestedVM && opcodeNests(OP_ICMP64)) {
+			Function* HelperFn = M.getFunction(kNestedIcmp64HelperName);
+			Value* Pred8 = B.CreateTrunc(Pred, I8Ty, "vm.ic64.pred8");
+			Value* Rv = B.CreateCall(HelperFn, { AV, BV, Pred8 }, "vm.ic64.nested");
+			stVR(B, Dst, Rv);
+			B.CreateBr(Dispatch);
+		} else {
+			using P = CmpInst::Predicate;
+			Value* Cs[] = {
+			  B.CreateICmpEQ(AV,BV), B.CreateICmpNE(AV,BV),
+			  B.CreateICmpUGT(AV,BV), B.CreateICmpUGE(AV,BV),
+			  B.CreateICmpULT(AV,BV), B.CreateICmpULE(AV,BV),
+			  B.CreateICmpSGT(AV,BV), B.CreateICmpSGE(AV,BV),
+			  B.CreateICmpSLT(AV,BV), B.CreateICmpSLE(AV,BV),
+			};
+			P Ps[] = { P::ICMP_EQ,P::ICMP_NE,P::ICMP_UGT,P::ICMP_UGE,P::ICMP_ULT,
+					   P::ICMP_ULE,P::ICMP_SGT,P::ICMP_SGE,P::ICMP_SLT,P::ICMP_SLE };
 
-		Value* R = B.getInt1(false);
-		for (unsigned i = 0; i < 10; i++)
-			R = B.CreateSelect(B.CreateICmpEQ(Pred, B.getInt32((uint32_t)Ps[i])), Cs[i], R);
+			Value* R = B.getInt1(false);
+			for (unsigned i = 0; i < 10; i++)
+				R = B.CreateSelect(B.CreateICmpEQ(Pred, B.getInt32((uint32_t)Ps[i])), Cs[i], R);
 
-		stVR(B, Dst, B.CreateZExt(R, I32Ty, "vm.ic64.r"));
-		B.CreateBr(Dispatch);
+			stVR(B, Dst, B.CreateZExt(R, I32Ty, "vm.ic64.r"));
+			B.CreateBr(Dispatch);
+		}
 	}
 
 
@@ -629,14 +1159,23 @@ void VMImpl::buildHandlersIntArith() {
 		Value* IP = advIP(B, 3);
 		Value* Dst = rdVR(B, IP, 0, "vm.ca.d"), * Src = rdVR(B, IP, 1, "vm.ca.s"), * Kind = rdByte(B, IP, 2, "vm.ca.k");
 		Value* SV = ldVR(B, Src);
-		auto ze = [&](uint32_t M) {return B.CreateAnd(SV, B.getInt32(M), "vm.ze"); };
-		auto se = [&](uint32_t W)->Value* {
-			return B.CreateAShr(B.CreateShl(SV, B.getInt32(32 - W), "vm.ssl"), B.getInt32(32 - W), "vm.ssr"); };
-		Value* Cvs[] = { ze(1),ze(0xFF),ze(0xFFFF),se(8),se(16),ze(1),ze(0xFF),ze(0xFFFF) };
-		Value* R = SV;
-		for (unsigned i = 0; i < 8; i++)
-			R = B.CreateSelect(B.CreateICmpEQ(Kind, B.getInt32(i)), Cvs[i], R, "vm.ca.r");
-		stVR(B, Dst, R); B.CreateBr(Dispatch);
+
+		if (NestedVM && opcodeNests(OP_CAST)) {
+			Function* HelperFn = M.getFunction(kNestedCastHelperName);
+			Value* Kind8 = B.CreateTrunc(Kind, I8Ty, "vm.ca.kind8");
+			Value* Rv = B.CreateCall(HelperFn, { SV, Kind8 }, "vm.ca.nested");
+			stVR(B, Dst, Rv);
+			B.CreateBr(Dispatch);
+		} else {
+			auto ze = [&](uint32_t M) {return B.CreateAnd(SV, B.getInt32(M), "vm.ze"); };
+			auto se = [&](uint32_t W)->Value* {
+				return B.CreateAShr(B.CreateShl(SV, B.getInt32(32 - W), "vm.ssl"), B.getInt32(32 - W), "vm.ssr"); };
+			Value* Cvs[] = { ze(1),ze(0xFF),ze(0xFFFF),se(8),se(16),ze(1),ze(0xFF),ze(0xFFFF) };
+			Value* R = SV;
+			for (unsigned i = 0; i < 8; i++)
+				R = B.CreateSelect(B.CreateICmpEQ(Kind, B.getInt32(i)), Cvs[i], R, "vm.ca.r");
+			stVR(B, Dst, R); B.CreateBr(Dispatch);
+		}
 	}
 }
 
@@ -1182,50 +1721,58 @@ void VMImpl::buildHandlersFloat() {
 		Value* AV = ldFR(B, AIdx);
 		Value* BV = ldFR(B, BIdx);
 
-		using FP = CmpInst::Predicate;
+		if (NestedVM && opcodeNests(OP_FCMP)) {
+			Function* HelperFn = M.getFunction(kNestedFcmpHelperName);
+			Value* Pred8 = B.CreateTrunc(Pred, I8Ty, "vm.fcp.pred8");
+			Value* Rv = B.CreateCall(HelperFn, { AV, BV, Pred8 }, "vm.fcp.nested");
+			stVR(B, Dst, Rv);
+			B.CreateBr(Dispatch);
+		} else {
+			using FP = CmpInst::Predicate;
 
-		BasicBlock* MergeBB = BasicBlock::Create(Ctx, "vm.fcp.merge", HFn);
-		BasicBlock* DefBB = BasicBlock::Create(Ctx, "vm.fcp.def", HFn);
+			BasicBlock* MergeBB = BasicBlock::Create(Ctx, "vm.fcp.merge", HFn);
+			BasicBlock* DefBB = BasicBlock::Create(Ctx, "vm.fcp.def", HFn);
 
-		// Default: FCMP_FALSE (pred=0) — result always 0.
-		SwitchInst* SW = B.CreateSwitch(Pred, DefBB, 14);
+			// Default: FCMP_FALSE (pred=0) — result always 0.
+			SwitchInst* SW = B.CreateSwitch(Pred, DefBB, 14);
 
-		// MergeBB: PHI first, then stVR, then br — same order as OP_BINOP.
-		IRBuilder<> BM(MergeBB);
-		auto* Phi = BM.CreatePHI(I32Ty, 15, "vm.fcp.r");
-		stVR(BM, Dst, Phi);
-		BM.CreateBr(Dispatch);
+			// MergeBB: PHI first, then stVR, then br — same order as OP_BINOP.
+			IRBuilder<> BM(MergeBB);
+			auto* Phi = BM.CreatePHI(I32Ty, 15, "vm.fcp.r");
+			stVR(BM, Dst, Phi);
+			BM.CreateBr(Dispatch);
 
-		// Default block handles FCMP_FALSE (pred==0): result is always 0.
-		{
-			IRBuilder<> BD(DefBB);
-			Phi->addIncoming(BD.getInt32(0), DefBB);
-			BD.CreateBr(MergeBB);
+			// Default block handles FCMP_FALSE (pred==0): result is always 0.
+			{
+				IRBuilder<> BD(DefBB);
+				Phi->addIncoming(BD.getInt32(0), DefBB);
+				BD.CreateBr(MergeBB);
+			}
+
+			auto addCase = [&](FP pred, const Twine& BBName, auto Emit) {
+				BasicBlock* CBB = BasicBlock::Create(Ctx, BBName, HFn);
+				IRBuilder<> BC(CBB);
+				Value* R = BC.CreateZExt(Emit(BC), I32Ty, "vm.fcp.z");
+				Phi->addIncoming(R, CBB);
+				BC.CreateBr(MergeBB);
+				SW->addCase(B.getInt32((uint32_t)pred), CBB);
+				};
+
+			addCase(FP::FCMP_OEQ, "vm.fcp.oeq", [&](IRBuilder<>& BC) { return BC.CreateFCmpOEQ(AV, BV, "vm.fcp.v"); });
+			addCase(FP::FCMP_OGT, "vm.fcp.ogt", [&](IRBuilder<>& BC) { return BC.CreateFCmpOGT(AV, BV, "vm.fcp.v"); });
+			addCase(FP::FCMP_OGE, "vm.fcp.oge", [&](IRBuilder<>& BC) { return BC.CreateFCmpOGE(AV, BV, "vm.fcp.v"); });
+			addCase(FP::FCMP_OLT, "vm.fcp.olt", [&](IRBuilder<>& BC) { return BC.CreateFCmpOLT(AV, BV, "vm.fcp.v"); });
+			addCase(FP::FCMP_OLE, "vm.fcp.ole", [&](IRBuilder<>& BC) { return BC.CreateFCmpOLE(AV, BV, "vm.fcp.v"); });
+			addCase(FP::FCMP_ONE, "vm.fcp.one", [&](IRBuilder<>& BC) { return BC.CreateFCmpONE(AV, BV, "vm.fcp.v"); });
+			addCase(FP::FCMP_ORD, "vm.fcp.ord", [&](IRBuilder<>& BC) { return BC.CreateFCmpORD(AV, BV, "vm.fcp.v"); });
+			addCase(FP::FCMP_UEQ, "vm.fcp.ueq", [&](IRBuilder<>& BC) { return BC.CreateFCmpUEQ(AV, BV, "vm.fcp.v"); });
+			addCase(FP::FCMP_UGT, "vm.fcp.ugt", [&](IRBuilder<>& BC) { return BC.CreateFCmpUGT(AV, BV, "vm.fcp.v"); });
+			addCase(FP::FCMP_UGE, "vm.fcp.uge", [&](IRBuilder<>& BC) { return BC.CreateFCmpUGE(AV, BV, "vm.fcp.v"); });
+			addCase(FP::FCMP_ULT, "vm.fcp.ult", [&](IRBuilder<>& BC) { return BC.CreateFCmpULT(AV, BV, "vm.fcp.v"); });
+			addCase(FP::FCMP_ULE, "vm.fcp.ule", [&](IRBuilder<>& BC) { return BC.CreateFCmpULE(AV, BV, "vm.fcp.v"); });
+			addCase(FP::FCMP_UNE, "vm.fcp.une", [&](IRBuilder<>& BC) { return BC.CreateFCmpUNE(AV, BV, "vm.fcp.v"); });
+			addCase(FP::FCMP_UNO, "vm.fcp.uno", [&](IRBuilder<>& BC) { return BC.CreateFCmpUNO(AV, BV, "vm.fcp.v"); });
 		}
-
-		auto addCase = [&](FP pred, const Twine& BBName, auto Emit) {
-			BasicBlock* CBB = BasicBlock::Create(Ctx, BBName, HFn);
-			IRBuilder<> BC(CBB);
-			Value* R = BC.CreateZExt(Emit(BC), I32Ty, "vm.fcp.z");
-			Phi->addIncoming(R, CBB);
-			BC.CreateBr(MergeBB);
-			SW->addCase(B.getInt32((uint32_t)pred), CBB);
-			};
-
-		addCase(FP::FCMP_OEQ, "vm.fcp.oeq", [&](IRBuilder<>& BC) { return BC.CreateFCmpOEQ(AV, BV, "vm.fcp.v"); });
-		addCase(FP::FCMP_OGT, "vm.fcp.ogt", [&](IRBuilder<>& BC) { return BC.CreateFCmpOGT(AV, BV, "vm.fcp.v"); });
-		addCase(FP::FCMP_OGE, "vm.fcp.oge", [&](IRBuilder<>& BC) { return BC.CreateFCmpOGE(AV, BV, "vm.fcp.v"); });
-		addCase(FP::FCMP_OLT, "vm.fcp.olt", [&](IRBuilder<>& BC) { return BC.CreateFCmpOLT(AV, BV, "vm.fcp.v"); });
-		addCase(FP::FCMP_OLE, "vm.fcp.ole", [&](IRBuilder<>& BC) { return BC.CreateFCmpOLE(AV, BV, "vm.fcp.v"); });
-		addCase(FP::FCMP_ONE, "vm.fcp.one", [&](IRBuilder<>& BC) { return BC.CreateFCmpONE(AV, BV, "vm.fcp.v"); });
-		addCase(FP::FCMP_ORD, "vm.fcp.ord", [&](IRBuilder<>& BC) { return BC.CreateFCmpORD(AV, BV, "vm.fcp.v"); });
-		addCase(FP::FCMP_UEQ, "vm.fcp.ueq", [&](IRBuilder<>& BC) { return BC.CreateFCmpUEQ(AV, BV, "vm.fcp.v"); });
-		addCase(FP::FCMP_UGT, "vm.fcp.ugt", [&](IRBuilder<>& BC) { return BC.CreateFCmpUGT(AV, BV, "vm.fcp.v"); });
-		addCase(FP::FCMP_UGE, "vm.fcp.uge", [&](IRBuilder<>& BC) { return BC.CreateFCmpUGE(AV, BV, "vm.fcp.v"); });
-		addCase(FP::FCMP_ULT, "vm.fcp.ult", [&](IRBuilder<>& BC) { return BC.CreateFCmpULT(AV, BV, "vm.fcp.v"); });
-		addCase(FP::FCMP_ULE, "vm.fcp.ule", [&](IRBuilder<>& BC) { return BC.CreateFCmpULE(AV, BV, "vm.fcp.v"); });
-		addCase(FP::FCMP_UNE, "vm.fcp.une", [&](IRBuilder<>& BC) { return BC.CreateFCmpUNE(AV, BV, "vm.fcp.v"); });
-		addCase(FP::FCMP_UNO, "vm.fcp.uno", [&](IRBuilder<>& BC) { return BC.CreateFCmpUNO(AV, BV, "vm.fcp.v"); });
 	}
 
 
@@ -1572,7 +2119,7 @@ void VMImpl::buildCall2(VMOp Opc, const Twine& Name, llvm::VMEngine::RetKind2 RK
 
 	// Store switch info for ensureCallFTyCases() to extend later.
 	if (SharedEngineMode) {
-		auto* SS = VMEngine::getSharedState(M);
+		auto* SS = VMEngine::getSharedState(M, EngineId);
 		auto& CSW = SS->CallSW[(unsigned)RK];
 		CSW.SW = FTySW;
 		CSW.MergeBB = MergeBB;
@@ -1612,7 +2159,7 @@ void VMImpl::buildHandlerTable() {
 	// load path so the connection is not trivially visible in the wrapper.
 	// In shared engine mode, OpcBB[] lives in vm_engine.
 	VMEngine::SharedState* SS =
-		SharedEngineMode ? VMEngine::getSharedState(M) : nullptr;
+		SharedEngineMode ? VMEngine::getSharedState(M, EngineId) : nullptr;
 	Function* BAFn = SharedEngineMode ? SS->EngineFn : &F;
 	unsigned K = SharedEngineMode ? SS->NumVariants : NumVariants;
 	bool ED = SharedEngineMode ? SS->EncDispatch : EncDispatch;
@@ -1627,14 +2174,14 @@ void VMImpl::buildHandlerTable() {
 	// Per-function random variant selection: fork does NOT consume the
 	// parent RNG stream, so at K==1 (vsel always 0, .range() never called)
 	// this is fully dormant and byte-identical to pre-variant behavior.
-	auto VarRng = VCtx.R.fork("vm.handler.variant");
+	auto VarRng = R.fork("vm.handler.variant");
 
 	// P2: secondary Fisher-Yates permutation of handler table slots.
 	// Identity when encDispatch is off (dormant, no RNG consumption).
 	uint8_t DispPerm[OP_COUNT];
 	for (unsigned i = 0; i < OP_COUNT; ++i) DispPerm[i] = (uint8_t)i;
 	if (ED) {
-		auto DR = VCtx.R.fork("vm.disp.perm");
+		auto DR = R.fork("vm.disp.perm");
 		for (unsigned i = OP_COUNT - 1; i > 0; --i) {
 			unsigned j = DR.range(i + 1);
 			uint8_t t = DispPerm[i]; DispPerm[i] = DispPerm[j]; DispPerm[j] = t;
@@ -1666,7 +2213,7 @@ void VMImpl::buildHandlerTable() {
 
 	// engine pointer in slot [OP_COUNT]
 	{
-		Function* EngFn = M.getFunction(VMEngine::kVMEngineName);
+		Function* EngFn = M.getFunction(VMEngine::vmEngineName(EngineId));
 		assert(EngFn && "vm_engine must exist before building handler table");
 		Es[OP_COUNT] = EngFn;
 	}
@@ -2032,7 +2579,10 @@ void VMImpl::buildEncryptCtorAES() {
 
 namespace {
 	static std::mutex SharedStateMu;
-	static DenseMap<Module*, std::unique_ptr<VMEngine::SharedState>> SharedStateMap;
+	// Keyed by (Module*, EngineId): EngineId 0 = plain engine, 1 = nesting
+	// engine. Each key gets its own independent SharedState, so the two
+	// engines' "first function populates" guards can never cross-contaminate.
+	static DenseMap<std::pair<Module*, unsigned>, std::unique_ptr<VMEngine::SharedState>> SharedStateMap;
 }
 
 namespace llvm {
@@ -2048,10 +2598,10 @@ namespace llvm {
 		};
 		static constexpr const char* kPopulatedMDKey = "obf.vm.engine.populated";
 
-		Function* getOrBuildVMEngine(Module& M) {
+		Function* getOrBuildVMEngine(Module& M, unsigned EngineId) {
 			// Lookup only — returns null if not yet created.
 			// populateVMEngine() handles atomic creation + population.
-			if (Function* Existing = M.getFunction(kVMEngineName)) {
+			if (Function* Existing = M.getFunction(vmEngineName(EngineId))) {
 				assert((Existing->arg_size() == kNumParams ||
 					Existing->arg_size() == kNumParams + 1) &&
 					"vm_engine parameter count mismatch");
@@ -2079,16 +2629,19 @@ namespace llvm {
 			VMEngineFunc->setMetadata(kPopulatedMDKey, TrueMD);
 		}
 
-		SharedState* getSharedState(Module& M) {
+		SharedState* getSharedState(Module& M, unsigned EngineId) {
 			std::lock_guard<std::mutex> LK(SharedStateMu);
-			auto& Ptr = SharedStateMap[&M];
+			auto& Ptr = SharedStateMap[{&M, EngineId}];
 			if (!Ptr) Ptr = std::make_unique<SharedState>();
 			return Ptr.get();
 		}
 
 		void releaseSharedState(Module& M) {
 			std::lock_guard<std::mutex> LK(SharedStateMu);
-			SharedStateMap.erase(&M);
+			SmallVector<std::pair<Module*, unsigned>, 4> ToErase;
+			for (auto& KV : SharedStateMap)
+				if (KV.first.first == &M) ToErase.push_back(KV.first);
+			for (auto& K : ToErase) SharedStateMap.erase(K);
 		}
 
 	} // namespace VMEngine
@@ -2124,7 +2677,7 @@ void VMImpl::setupEffLocal() {
 // populateVMEngine: build all handlers inside shared vm_engine 
 
 void VMImpl::populateVMEngine() {
-	auto* SS = VMEngine::getSharedState(M);
+	auto* SS = VMEngine::getSharedState(M, EngineId);
 	if (SS->Populated) return;
 
 	// Create __vm_engine AND populate it atomically 
@@ -2135,7 +2688,7 @@ void VMImpl::populateVMEngine() {
 
 	FunctionType* FTy = VMEngine::getVMEngineFunctionType(Ctx, LazyDecrypt);
 	Function* EF = Function::Create(FTy, GlobalValue::InternalLinkage,
-		VMEngine::kVMEngineName, &M);
+		VMEngine::vmEngineName(EngineId), &M);
 
 	// CRITICAL: Create the entry block IMMEDIATELY after Function::Create.
 	// The function must never be observable with an empty block list —
@@ -2220,10 +2773,10 @@ void VMImpl::populateVMEngine() {
 	SS->Dispatch = Dispatch;
 
 	// Build all 51 opcode handlers
-	NumVariants = VCtx.Cfg.handlerVariants;
+	NumVariants = Cfg.handlerVariants;
 	if (NumVariants < 1) NumVariants = 1;
 	if (NumVariants > kMaxHandlerVariants) NumVariants = kMaxHandlerVariants;
-	EncDispatch = VCtx.Cfg.encDispatch;
+	EncDispatch = Cfg.encDispatch;
 	buildOpcodeHandlers();
 
 	// Make the K structurally-identical variants distinct (per-variant MBA).
@@ -2247,7 +2800,7 @@ void VMImpl::populateVMEngine() {
 	SS->FTyCountAtLastBuild = (unsigned)SS->SharedFTys.size();
 	VMEngine::markEnginePopulated(EF);
 
-	if (VCtx.Cfg.hardened)
+	if (Cfg.hardened)
 		hardenVMEngine(EF, SS);
 
 	LLVM_DEBUG(dbgs() << "[vm] populated vm_engine with "
@@ -2295,7 +2848,7 @@ static bool isHandlerBlock(const BasicBlock& BB) {
 void VMImpl::hardenVMEngine(Function* EF, VMEngine::SharedState* SS) {
 	if (!EF || !SS) return;
 
-	auto HardenRng = VCtx.R.fork("vm.harden");
+	auto HardenRng = R.fork("vm.harden");
 	llvm::obf::OpaqueUtils Opaque(M, HardenRng, "vm.opaque.salt.i32");
 	llvm::obf::MbaUtils MBA(M, HardenRng, "obf.vm.mba.noise.i32");
 
@@ -2478,7 +3031,7 @@ void VMImpl::hardenVMEngine(Function* EF, VMEngine::SharedState* SS) {
 	// The check is self-contained within the handler block — no cross-BB
 	// alloca needed.
 	unsigned HandlerTraps = 0;
-	if (VCtx.Cfg.antiDebug && (TI.IsX86_64 || TI.IsAArch64)) {
+	if (Cfg.antiDebug && (TI.IsX86_64 || TI.IsAArch64)) {
 		Function* RCC = Intrinsic::getOrInsertDeclaration(&M, Intrinsic::readcyclecounter);
 
 
@@ -2493,7 +3046,7 @@ void VMImpl::hardenVMEngine(Function* EF, VMEngine::SharedState* SS) {
 			// and their cumulative false-positive exposure. Keep trap count
 			// independent of K. (At K=1 every handler block is variant 0.)
 			if (VariantOf.lookup(&BB) != 0) continue;
-			if (HardenRng.range(100) >= (int)VCtx.Cfg.adHandlerProb) continue;
+			if (HardenRng.range(100) >= (int)Cfg.adHandlerProb) continue;
 
 			TrapCandidates.push_back(&BB);
 		}
@@ -2523,7 +3076,7 @@ void VMImpl::hardenVMEngine(Function* EF, VMEngine::SharedState* SS) {
 
 			Value* Delta = B.CreateSub(T2, T1, "vm.ad.h.delta");
 			Value* Slow = B.CreateICmpUGT(Delta,
-				B.getInt64((uint64_t)VCtx.Cfg.adHandlerThreshold),
+				B.getInt64((uint64_t)Cfg.adHandlerThreshold),
 				"vm.ad.h.slow");
 
 			// One-shot gate: poison only if slow AND not yet fired.
@@ -2581,7 +3134,7 @@ void VMImpl::hardenVMEngine(Function* EF, VMEngine::SharedState* SS) {
 void VMImpl::diversifyHandlerVariants(Function* EF) {
 	if (!EF || NumVariants < 2) return;
 
-	auto DivRng = VCtx.R.fork("vm.variant.diversify");
+	auto DivRng = R.fork("vm.variant.diversify");
 	llvm::obf::MbaUtils   MBA(M, DivRng, "obf.vm.variant.mba.i32");
 	llvm::obf::OpaqueUtils Opaque(M, DivRng, "vm.variant.opaque.i32");
 
@@ -2661,7 +3214,7 @@ void VMImpl::diversifyHandlerVariants(Function* EF) {
 // inside __vm_engine.
 
 void VMImpl::ensureCallFTyCases() {
-	auto* SS = VMEngine::getSharedState(M);
+	auto* SS = VMEngine::getSharedState(M, EngineId);
 	if (!SS->Populated) return;
 	unsigned OldCount = SS->FTyCountAtLastBuild;
 	unsigned NewCount = (unsigned)SS->SharedFTys.size();
@@ -2801,9 +3354,9 @@ void VMImpl::buildWrapper() {
 	// keys, encrypted values, engine-table index) are materialised through
 	// opaque expression trees instead of bare immediates.  Structural
 	// constants (GEP indices, alloca sizes) are left as-is.
-	auto WrapBlindRng = VCtx.R.fork("vm.wrap.blind");
+	auto WrapBlindRng = R.fork("vm.wrap.blind");
 	llvm::obf::OpaqueUtils WrapOpaque(M, WrapBlindRng, "vm.wrap.opaque.i32");
-	const bool Blind = VCtx.Cfg.hardened;
+	const bool Blind = Cfg.hardened;
 
 	auto blindI32 = [&](uint32_t C) -> Value* {
 		if (!Blind) return B.getInt32(C);
@@ -2823,8 +3376,8 @@ void VMImpl::buildWrapper() {
 
 
 	// per-function polymorphism RNG
-	auto PolyRng = VCtx.R.fork("vm.wrap.poly");
-	const bool Poly = VCtx.Cfg.hardened;
+	auto PolyRng = R.fork("vm.wrap.poly");
+	const bool Poly = Cfg.hardened;
 
 	// Fisher-Yates shuffle helper
 	auto fyShuffle = [&](unsigned* Arr, unsigned N) {
@@ -3085,7 +3638,7 @@ void VMImpl::buildWrapper() {
 	// Gated on SS->LazyMode (fixed by whichever function founded the shared
 	// engine), not this function's own LazyDecrypt: the wrapper's argument
 	// list must match the already-built engine signature regardless.
-	auto* SS = VMEngine::getSharedState(M);
+	auto* SS = VMEngine::getSharedState(M, EngineId);
 	const bool LazyActive = SS->LazyMode;
 	Value* LazyCtxArg = nullptr;
 	if (LazyActive) {
@@ -3186,7 +3739,7 @@ void VMImpl::buildWrapper() {
 		DoRegEncrypt ? (Value*)WFRegKeys                                 // fregkeys
 			: ConstantPointerNull::get(cast<PointerType>(PtrTy)),
 		// per-function callee XOR mask (0 when unhardened)
-		VCtx.Cfg.hardened ? blindI64(CalleeMask) : B.getInt64(0),       // callee_mask
+		Cfg.hardened ? blindI64(CalleeMask) : B.getInt64(0),       // callee_mask
 	};
 	if (LazyActive) Args.push_back(LazyCtxArg);              // lazyctx
 
@@ -3281,7 +3834,7 @@ void VMImpl::buildWrapper() {
 //   - each edge gets: if (hardTrue) goto RealPhase else goto JunkBlock
 //   - 3-5 fully dead blocks with junk stores and opaque constants
 //
-// Gated by VCtx.Cfg.hardened — no-op when hardened=0.
+// Gated by Cfg.hardened — no-op when hardened=0.
 
 
 //salt corruption primitive
@@ -3311,7 +3864,7 @@ void VMImpl::emitSaltCorruption(IRBuilder<>& B, Value* SaltPtr, uint32_t PoisonK
 // Gated by hardened=1 && antiDebug=1.
 
 void VMImpl::buildIntegrityHashCtor() {
-	if (!VCtx.Cfg.hardened || !VCtx.Cfg.antiDebug) return;
+	if (!Cfg.hardened || !Cfg.antiDebug) return;
 	if (!GVBytecode || E.BC.empty()) return;
 
 	unsigned BCLen = (unsigned)E.BC.size();
@@ -3432,7 +3985,7 @@ void VMImpl::buildIntegrityHashCtor() {
 // Gated by hardened=1 and non-empty callee table.
 
 void VMImpl::buildCalleeXorCtor() {
-	if (!VCtx.Cfg.hardened || !GVCallees || E.CalleeTab.empty()) return;
+	if (!Cfg.hardened || !GVCallees || E.CalleeTab.empty()) return;
 	if (CalleeMask == 0) return;
 
 	unsigned NCallees = (unsigned)E.CalleeTab.size();
@@ -3481,7 +4034,7 @@ void VMImpl::buildCalleeXorCtor() {
 // that the branch predictor learns is almost-always-false (~1 cycle).
 
 void VMImpl::buildAntiDebugGate(VMEngine::SharedState* SS) {
-	if (!VCtx.Cfg.hardened || !VCtx.Cfg.antiDebug) return;
+	if (!Cfg.hardened || !Cfg.antiDebug) return;
 	if (!SS || !SS->EngineFn || !SS->Dispatch || !SS->EngineSalt) return;
 
 	Function* EF = SS->EngineFn;
@@ -3512,7 +4065,7 @@ void VMImpl::buildAntiDebugGate(VMEngine::SharedState* SS) {
 		auto* NCtr = B.CreateAdd(Ctr, B.getInt32(1), "vm.ad.cn");
 		B.CreateStore(NCtr, CtrA)->setVolatile(true);
 		// interval from config (rounded to power-of-2 for AND mask)
-		unsigned Interval = VCtx.Cfg.adDispatchInterval;
+		unsigned Interval = Cfg.adDispatchInterval;
 		if (Interval == 0) Interval = 64;
 		unsigned Mask = 1;
 		while (Mask < Interval) Mask <<= 1;
@@ -3561,7 +4114,7 @@ void VMImpl::buildAntiDebugGate(VMEngine::SharedState* SS) {
 			auto* Delta = B.CreateSub(T2, T1, "vm.ad.delta");
 			// threshold from config
 			auto* Slow = B.CreateICmpUGT(Delta,
-				B.getInt64((uint64_t)VCtx.Cfg.adDispatchThreshold), "vm.ad.slow");
+				B.getInt64((uint64_t)Cfg.adDispatchThreshold), "vm.ad.slow");
 			Detected = B.CreateOr(Detected, Slow, "vm.ad.det.time");
 		}
 
@@ -3680,9 +4233,9 @@ void VMImpl::buildAntiDebugGate(VMEngine::SharedState* SS) {
 
 
 void VMImpl::hardenWrapper() {
-	if (!VCtx.Cfg.hardened) return;
+	if (!Cfg.hardened) return;
 
-	auto HRng = VCtx.R.fork("vm.wrap.split");
+	auto HRng = R.fork("vm.wrap.split");
 	llvm::obf::OpaqueUtils HOpaque(M, HRng, "vm.wrap.split.i32");
 	BasicBlock* EntryBB = &F.getEntryBlock();
 	if (!EntryBB || EntryBB->empty()) return;
@@ -3796,12 +4349,12 @@ void VMImpl::hardenWrapper() {
 // sees: state ^= <opaque_delta>;  This prevents trivial state recovery.
 //
 // Blocks that terminate with ret/unreachable are left as function exits.
-// Gated by VCtx.Cfg.hardened — no-op when hardened=0.
+// Gated by Cfg.hardened — no-op when hardened=0.
 
 void VMImpl::flattenWrapper() {
-	if (!VCtx.Cfg.hardened) return;
+	if (!Cfg.hardened) return;
 
-	auto FRng = VCtx.R.fork("vm.wrap.flat");
+	auto FRng = R.fork("vm.wrap.flat");
 	llvm::obf::OpaqueUtils FOpaque(M, FRng, "vm.wrap.flat.i32");
 
 	BasicBlock* EntryBB = &F.getEntryBlock();
@@ -3919,12 +4472,12 @@ void VMImpl::flattenWrapper() {
 //
 // Operates on all basic blocks of the wrapper function (including the
 // phase blocks and dead blocks created by hardenWrapper).
-// Gated by VCtx.Cfg.hardened — no-op when hardened=0.
+// Gated by Cfg.hardened — no-op when hardened=0.
 
 void VMImpl::mbaHardenWrapper() {
-	if (!VCtx.Cfg.hardened) return;
+	if (!Cfg.hardened) return;
 
-	auto MRng = VCtx.R.fork("vm.wrap.mba");
+	auto MRng = R.fork("vm.wrap.mba");
 	llvm::obf::MbaUtils    WMBA(M, MRng, "vm.wrap.mba.noise.i32");
 	llvm::obf::OpaqueUtils WOpq(M, MRng, "vm.wrap.mba.salt.i32");
 
@@ -4229,7 +4782,7 @@ bool VMImpl::run() {
 	// distinct label ("vm.regkeys") so they do not perturb any existing
 	// RNG sequence.  One key per allocated slot (power-of-2 padded).
 	if (RegEncrypt) {
-		auto KeyRng = VCtx.R.fork("vm.regkeys");
+		auto KeyRng = R.fork("vm.regkeys");
 		RegKeys.resize(NVRAlloc);
 		for (auto& K : RegKeys)   K = (uint32_t)KeyRng.u32();
 		Reg64Keys.resize(NVR64Alloc);
@@ -4247,7 +4800,7 @@ bool VMImpl::run() {
 	// Generate per-function engine-pointer XOR mask 
 	// Uses a forked RNG so it does not perturb any existing sequence.
 	{
-		auto EngRng = VCtx.R.fork("vm.engine.mask");
+		auto EngRng = R.fork("vm.engine.mask");
 		EngineMask = ((uint64_t)EngRng.u32() << 32) | EngRng.u32();
 		// Ensure mask is non-zero to avoid storing the raw pointer.
 		if (EngineMask == 0) EngineMask = 0xDEADBEEFCAFEBABEULL;
@@ -4255,7 +4808,7 @@ bool VMImpl::run() {
 
 	// generate anti-debug poison key + init TargetInfo 
 	{
-		auto ADRng = VCtx.R.fork("vm.antidebug");
+		auto ADRng = R.fork("vm.antidebug");
 		ADPoisonKey = ADRng.u32();
 		if (ADPoisonKey == 0) ADPoisonKey = 0xDEAD07u;
 	}
@@ -4263,7 +4816,7 @@ bool VMImpl::run() {
 
 	// generate per-function callee XOR mask 
 	{
-		auto CMRng = VCtx.R.fork("vm.callee.mask");
+		auto CMRng = R.fork("vm.callee.mask");
 		CalleeMask = ((uint64_t)CMRng.u32() << 32) | CMRng.u32();
 		if (CalleeMask == 0) CalleeMask = 0xCAFEBABE08080808ULL;
 	}
@@ -4280,14 +4833,28 @@ bool VMImpl::run() {
 	buildBytecodeGlobal();
 	buildCalleeGlobal();
 
+	// Nested-VM: each eligible opcode's helper Function* must exist before
+	// buildOpcodeHandlers (inside populateVMEngine, below) can emit a call to
+	// it. See the sequencing note above virtualizeNestedHelpersOnce().
+	if (NestedVM) {
+		for (const auto& H : kNestedHelperOrder)
+			if (opcodeNests(H.Op))
+				getOrCreateNestedHelper(H.Op);
+	}
+
 	// Populate shared vm_engine (first function only)
 	populateVMEngine();
+
+	// Nested-VM: inner-virtualize the helper(s), once per module. Must run
+	// AFTER populateVMEngine() above -- see sequencing note.
+	if (NestedVM)
+		virtualizeNestedHelpersOnce();
 
 	// Extend CALL handler switches if this function introduced new FTys
 	ensureCallFTyCases();
 
 	// Build per-function handler table (uses shared OpcBB with per-function permutation)
-	VMEngine::getSharedState(M); // ensure shared state exists before table build
+	VMEngine::getSharedState(M, EngineId); // ensure shared state exists before table build
 	SharedEngineMode = true;
 	buildHandlerTable();
 	SharedEngineMode = false;

--- a/VMPass_Impl.cpp
+++ b/VMPass_Impl.cpp
@@ -462,6 +462,7 @@ namespace {
 	constexpr const char* kNestedIcmp64HelperName = "__vm_h_icmp64";
 	constexpr const char* kNestedFcmpHelperName = "__vm_h_fcmp";
 	constexpr const char* kNestedCastHelperName = "__vm_h_cast";
+	constexpr const char* kNestedBinopFHelperName = "__vm_h_binop_f";
 
 	// Fixed deterministic nesting order, consumed by run() (helper creation),
 	// opcodeNests() (the nestedVMOpcodes cap), and virtualizeNestedHelpersOnce()
@@ -475,6 +476,7 @@ namespace {
 		{ OP_ICMP64,  kNestedIcmp64HelperName },
 		{ OP_FCMP,    kNestedFcmpHelperName },
 		{ OP_CAST,    kNestedCastHelperName },
+		{ OP_BINOP_F, kNestedBinopFHelperName },
 	};
 	constexpr unsigned kNumNestedHelpers =
 		sizeof(kNestedHelperOrder) / sizeof(kNestedHelperOrder[0]);
@@ -497,6 +499,7 @@ Function* VMImpl::getOrCreateNestedHelper(VMOp Op) {
 	case OP_ICMP64:  return getOrCreateNestedIcmp64Helper();
 	case OP_FCMP:    return getOrCreateNestedFcmpHelper();
 	case OP_CAST:    return getOrCreateNestedCastHelper();
+	case OP_BINOP_F: return getOrCreateNestedBinopFHelper();
 	default:         return nullptr;
 	}
 }
@@ -871,6 +874,65 @@ Function* VMImpl::getOrCreateNestedCastHelper() {
 	return HF;
 }
 
+// Pure helper `double __vm_h_binop_f(double a, double b, i8 subop)` -- replicates
+// OP_BINOP_F's compute (buildHandlersFloat). subop bits[6:0] = FBinSubop, bit[7]
+// = f32-mode flag: when set, the f64 result is rounded to f32 precision
+// (fptrunc->fpext), matching native float arithmetic. Plain (no fast-math) FP
+// ops, mirroring the handler. Default case is FBS_FADD.
+Function* VMImpl::getOrCreateNestedBinopFHelper() {
+	if (Function* Existing = M.getFunction(kNestedBinopFHelperName))
+		return Existing;
+
+	FunctionType* FTy = FunctionType::get(DoubleTy, { DoubleTy, DoubleTy, I8Ty }, false);
+	Function* HF = Function::Create(FTy, GlobalValue::InternalLinkage,
+		kNestedBinopFHelperName, &M);
+	HF->addFnAttr(Attribute::NoUnwind);
+	Argument* AArg = HF->getArg(0); AArg->setName("a");
+	Argument* BArg = HF->getArg(1); BArg->setName("b");
+	Argument* SubArg = HF->getArg(2); SubArg->setName("subop");
+
+	BasicBlock* EntryBB = BasicBlock::Create(Ctx, "entry", HF);
+	IRBuilder<> B(EntryBB);
+	Value* Sub32 = B.CreateZExt(SubArg, I32Ty, "sub32");
+	Value* Op = B.CreateAnd(Sub32, B.getInt32(0x7F), "op");      // FBinSubop
+	Value* IsF32 = B.CreateICmpNE(
+		B.CreateAnd(Sub32, B.getInt32(0x80), "f32b"), B.getInt32(0), "f32");
+
+	BasicBlock* MergeBB = BasicBlock::Create(Ctx, "merge", HF);
+	BasicBlock* DefBB = BasicBlock::Create(Ctx, "def", HF);
+	SwitchInst* SW = B.CreateSwitch(Op, DefBB, 5);
+
+	IRBuilder<> BM(MergeBB);
+	auto* Phi = BM.CreatePHI(DoubleTy, 6, "r");
+	// Round to f32 precision when bit 7 was set (matches the handler).
+	Value* Narrow = BM.CreateFPExt(
+		BM.CreateFPTrunc(Phi, Type::getFloatTy(Ctx), "nt"), DoubleTy, "ne");
+	Value* Final = BM.CreateSelect(IsF32, Narrow, Phi, "fin");
+	BM.CreateRet(Final);
+
+	{
+		// Default implements FBS_FADD (matches OP_BINOP_F's fallback).
+		IRBuilder<> BD(DefBB);
+		Phi->addIncoming(BD.CreateFAdd(AArg, BArg, "fadd"), DefBB);
+		BD.CreateBr(MergeBB);
+	}
+
+	auto addCase = [&](uint32_t Case, const Twine& Name, auto Emit) {
+		BasicBlock* CBB = BasicBlock::Create(Ctx, Name, HF);
+		IRBuilder<> BC(CBB);
+		Phi->addIncoming(Emit(BC), CBB);
+		BC.CreateBr(MergeBB);
+		SW->addCase(B.getInt32(Case), CBB);
+		};
+
+	addCase(FBS_FSUB, "fsub", [&](IRBuilder<>& BC) { return BC.CreateFSub(AArg, BArg, "fsub"); });
+	addCase(FBS_FMUL, "fmul", [&](IRBuilder<>& BC) { return BC.CreateFMul(AArg, BArg, "fmul"); });
+	addCase(FBS_FDIV, "fdiv", [&](IRBuilder<>& BC) { return BC.CreateFDiv(AArg, BArg, "fdiv"); });
+	addCase(FBS_FREM, "frem", [&](IRBuilder<>& BC) { return BC.CreateFRem(AArg, BArg, "frem"); });
+
+	return HF;
+}
+
 // Inner-virtualize every created pure helper, exactly once per module. Must
 // run AFTER populateVMEngine() -- see the sequencing note above. Loops over
 // the fixed nesting order; a helper not found by name was never referenced
@@ -883,6 +945,11 @@ void VMImpl::virtualizeNestedHelpersOnce() {
 	VMPassConfig InnerCfg = Cfg;
 	InnerCfg.nestedVM = false; // hard recursion guard: no helper is ever itself nested
 	InnerCfg.minBlocks = 1;    // helper is a single small switch
+	// NOTE: NestedVMHardened is reserved. Hardening the helper's thin wrapper
+	// via the standard wrapper-hardening passes currently yields dominance-
+	// invalid IR on the helper's small wrapper shape; left off until that is
+	// fixed. The distinct inner engine already provides the second layer.
+	InnerCfg.hardened = false;
 
 	for (unsigned i = 0; i < kNumNestedHelpers; ++i) {
 		Function* HelperFn = M.getFunction(kNestedHelperOrder[i].Name);
@@ -1663,10 +1730,21 @@ void VMImpl::buildHandlersFloat() {
 		Value* AIdx = rdFR(B, IP, 1, "vm.bof.a");
 		Value* BIdx = rdFR(B, IP, 2, "vm.bof.b");
 		Value* Sub8 = rdByte(B, IP, 3, "vm.bof.op");   // raw byte incl. bit7
+		Value* AV = ldFR(B, AIdx), * BV = ldFR(B, BIdx);
+
+		if (NestedVM && opcodeNests(OP_BINOP_F)) {
+			// Compute via the pure helper (separately inner-virtualized). The
+			// helper takes the full subop byte and applies the f32 rounding
+			// itself, so the result is final.
+			Function* HelperFn = M.getFunction(kNestedBinopFHelperName);
+			Value* Sub8b = B.CreateTrunc(Sub8, I8Ty, "vm.bof.sub8");
+			Value* Rv = B.CreateCall(HelperFn, { AV, BV, Sub8b }, "vm.bof.nested");
+			stFR(B, Dst, Rv);
+			B.CreateBr(Dispatch);
+		} else {
 		Value* Sub = B.CreateAnd(Sub8, B.getInt32(0x7F), "vm.bof.sub"); // op only
 		Value* IsF32 = B.CreateICmpNE(
 			B.CreateAnd(Sub8, B.getInt32(0x80)), B.getInt32(0), "vm.bof.f32");
-		Value* AV = ldFR(B, AIdx), * BV = ldFR(B, BIdx);
 
 		// Carry IsF32 (i1) into the merge block via alloca so every incoming
 		// edge can read it without duplicating the comparison.
@@ -1704,6 +1782,7 @@ void VMImpl::buildHandlersFloat() {
 		addFCase(FBS_FMUL, "vm.bof.mul", [&](IRBuilder<>& BC) { return BC.CreateFMul(AV, BV, "vm.fmul"); });
 		addFCase(FBS_FDIV, "vm.bof.div", [&](IRBuilder<>& BC) { return BC.CreateFDiv(AV, BV, "vm.fdiv"); });
 		addFCase(FBS_FREM, "vm.bof.rem", [&](IRBuilder<>& BC) { return BC.CreateFRem(AV, BV, "vm.frem"); });
+		}
 	}
 
 	// OP_FCMP -- [dst_vr:u8 a_fr:u8 b_fr:u8 pred:u8] 

--- a/VMPass_Impl.cpp
+++ b/VMPass_Impl.cpp
@@ -438,7 +438,19 @@ void VMImpl::buildHandlersIntArith() {
 		B.CreateBr(Dispatch);
 	}
 
-	//  OP_MOVR  [dst:u8 src:u8] -- vreg[dst] = vreg[src] 
+	//  OP_LOADI64  [dst64:u8 imm:i64le] -- vreg64[dst] = imm
+	{
+		auto B = mkOpc(OP_LOADI64, "loadi64");
+		Value* IP = advIP(B, 9);
+		Value* Dst = rdVR64(B, IP, 0, "vm.li64.d");
+		Value* Lo = B.CreateZExt(rdU32(B, IP, 1, "vm.li64.lo"), I64Ty, "vm.li64.loz");
+		Value* Hi = B.CreateZExt(rdU32(B, IP, 5, "vm.li64.hi"), I64Ty, "vm.li64.hiz");
+		Value* Imm = B.CreateOr(Lo, B.CreateShl(Hi, B.getInt64(32), "vm.li64.hs"), "vm.li64.v");
+		stVR64(B, Dst, Imm);
+		B.CreateBr(Dispatch);
+	}
+
+	//  OP_MOVR  [dst:u8 src:u8] -- vreg[dst] = vreg[src]
 	{
 		auto B = mkOpc(OP_MOVR, "movr");
 		Value* IP = advIP(B, 2);
@@ -4189,6 +4201,7 @@ bool VMImpl::run() {
 	// Compile function body to bytecode
 	E.setOpcodeMap(&OpMap);
 	E.setTargetBlind(SaltConst, BlindTargets);
+	E.setConstInStream(ConstInStream);
 	if (!E.run(F, CTSalt, M.getDataLayout())) {
 		FailReason = E.getFailReason().str();
 		if (FailReason.empty()) FailReason = "bytecode emission failed";

--- a/VMPass_Impl.cpp
+++ b/VMPass_Impl.cpp
@@ -993,7 +993,7 @@ void VMImpl::buildHandlersIntArith() {
 		auto B = mkOpc(OP_LOADI, "loadi");
 		Value* IP = advIP(B, 5);
 		stVR(B, rdVR(B, IP, 0, "vm.li.d"), rdU32(B, IP, 1, "vm.li.i"));
-		B.CreateBr(Dispatch);
+		nextInsn(B);
 	}
 
 	//  OP_LOADI64  [dst64:u8 imm:i64le] -- vreg64[dst] = imm
@@ -1005,7 +1005,7 @@ void VMImpl::buildHandlersIntArith() {
 		Value* Hi = B.CreateZExt(rdU32(B, IP, 5, "vm.li64.hi"), I64Ty, "vm.li64.hiz");
 		Value* Imm = B.CreateOr(Lo, B.CreateShl(Hi, B.getInt64(32), "vm.li64.hs"), "vm.li64.v");
 		stVR64(B, Dst, Imm);
-		B.CreateBr(Dispatch);
+		nextInsn(B);
 	}
 
 	//  OP_MOVR  [dst:u8 src:u8] -- vreg[dst] = vreg[src]
@@ -1013,7 +1013,7 @@ void VMImpl::buildHandlersIntArith() {
 		auto B = mkOpc(OP_MOVR, "movr");
 		Value* IP = advIP(B, 2);
 		stVR(B, rdVR(B, IP, 0, "vm.mr.d"), ldVR(B, rdVR(B, IP, 1, "vm.mr.s")));
-		B.CreateBr(Dispatch);
+		nextInsn(B);
 	}
 
 	//  OP_BINOP  -- [dst:u8 a:u8 b:u8 subop:u8] 
@@ -1037,7 +1037,7 @@ void VMImpl::buildHandlersIntArith() {
 			Value* Sub8 = B.CreateTrunc(Sub, I8Ty, "vm.bo.sub8");
 			Value* Rv = B.CreateCall(HelperFn, { AV, BV, Sub8 }, "vm.bo.nested");
 			stVR(B, Dst, Rv);
-			B.CreateBr(Dispatch);
+			nextInsn(B);
 		} else {
 			BasicBlock* MergeBB = BasicBlock::Create(Ctx, "vm.bo.merge", HFn);
 			BasicBlock* DefBB = BasicBlock::Create(Ctx, "vm.bo.def", HFn);
@@ -1049,7 +1049,7 @@ void VMImpl::buildHandlersIntArith() {
 			IRBuilder<> BM(MergeBB);
 			auto* Phi = BM.CreatePHI(I32Ty, 13, "vm.bo.r");
 			stVR(BM, Dst, Phi);
-			BM.CreateBr(Dispatch);
+			nextInsn(BM);
 
 			{
 				IRBuilder<> BD(DefBB);
@@ -1102,7 +1102,7 @@ void VMImpl::buildHandlersIntArith() {
 			Value* Sub8 = B.CreateTrunc(Sub, I8Ty, "vm.bo64.sub8");
 			Value* Rv = B.CreateCall(HelperFn, { AV, BV, Sub8 }, "vm.bo64.nested");
 			stVR64(B, Dst, Rv);
-			B.CreateBr(Dispatch);
+			nextInsn(B);
 		} else {
 			BasicBlock* MergeBB = BasicBlock::Create(Ctx, "vm.bo64.merge", HFn);
 			BasicBlock* DefBB = BasicBlock::Create(Ctx, "vm.bo64.def", HFn);
@@ -1113,7 +1113,7 @@ void VMImpl::buildHandlersIntArith() {
 			IRBuilder<> BM(MergeBB);
 			auto* Phi = BM.CreatePHI(I64Ty, 13, "vm.bo64.r");
 			stVR64(BM, Dst, Phi);
-			BM.CreateBr(Dispatch);
+			nextInsn(BM);
 
 			{
 				IRBuilder<> BD(DefBB);
@@ -1158,7 +1158,7 @@ void VMImpl::buildHandlersIntArith() {
 			Value* Pred8 = B.CreateTrunc(Pred, I8Ty, "vm.ic.pred8");
 			Value* Rv = B.CreateCall(HelperFn, { AV, BV, Pred8 }, "vm.ic.nested");
 			stVR(B, Dst, Rv);
-			B.CreateBr(Dispatch);
+			nextInsn(B);
 		} else {
 			using P = CmpInst::Predicate;
 			Value* Cs[] = {
@@ -1173,7 +1173,7 @@ void VMImpl::buildHandlersIntArith() {
 			Value* R = B.getInt1(false);
 			for (unsigned i = 0; i < 10; i++)
 				R = B.CreateSelect(B.CreateICmpEQ(Pred, B.getInt32((uint32_t)Ps[i])), Cs[i], R);
-			stVR(B, Dst, B.CreateZExt(R, I32Ty, "vm.ic.r")); B.CreateBr(Dispatch);
+			stVR(B, Dst, B.CreateZExt(R, I32Ty, "vm.ic.r")); nextInsn(B);
 		}
 	}
 
@@ -1197,7 +1197,7 @@ void VMImpl::buildHandlersIntArith() {
 			Value* Pred8 = B.CreateTrunc(Pred, I8Ty, "vm.ic64.pred8");
 			Value* Rv = B.CreateCall(HelperFn, { AV, BV, Pred8 }, "vm.ic64.nested");
 			stVR(B, Dst, Rv);
-			B.CreateBr(Dispatch);
+			nextInsn(B);
 		} else {
 			using P = CmpInst::Predicate;
 			Value* Cs[] = {
@@ -1215,7 +1215,7 @@ void VMImpl::buildHandlersIntArith() {
 				R = B.CreateSelect(B.CreateICmpEQ(Pred, B.getInt32((uint32_t)Ps[i])), Cs[i], R);
 
 			stVR(B, Dst, B.CreateZExt(R, I32Ty, "vm.ic64.r"));
-			B.CreateBr(Dispatch);
+			nextInsn(B);
 		}
 	}
 
@@ -1232,7 +1232,7 @@ void VMImpl::buildHandlersIntArith() {
 			Value* Kind8 = B.CreateTrunc(Kind, I8Ty, "vm.ca.kind8");
 			Value* Rv = B.CreateCall(HelperFn, { SV, Kind8 }, "vm.ca.nested");
 			stVR(B, Dst, Rv);
-			B.CreateBr(Dispatch);
+			nextInsn(B);
 		} else {
 			auto ze = [&](uint32_t M) {return B.CreateAnd(SV, B.getInt32(M), "vm.ze"); };
 			auto se = [&](uint32_t W)->Value* {
@@ -1241,7 +1241,7 @@ void VMImpl::buildHandlersIntArith() {
 			Value* R = SV;
 			for (unsigned i = 0; i < 8; i++)
 				R = B.CreateSelect(B.CreateICmpEQ(Kind, B.getInt32(i)), Cvs[i], R, "vm.ca.r");
-			stVR(B, Dst, R); B.CreateBr(Dispatch);
+			stVR(B, Dst, R); nextInsn(B);
 		}
 	}
 }
@@ -1277,7 +1277,7 @@ void VMImpl::buildHandlersConv() {
 			Value* FP = ldPR(BP, rdPR(BP, IP, 4, "vm.sl.pf"));
 			Value* Bool = BP.CreateICmpNE(ldVR(BP, Cond), BP.getInt32(0), "vm.sl.pb");
 			stPR(BP, DstP, BP.CreateSelect(Bool, TP, FP, "vm.sl.pr"));
-			BP.CreateBr(Dispatch);
+			nextInsn(BP);
 		}
 
 		//  int path 
@@ -1289,7 +1289,7 @@ void VMImpl::buildHandlersConv() {
 			Value* FV = ldVR(BI, rdVR(BI, IP, 4, "vm.sl.if"));
 			Value* Bool = BI.CreateICmpNE(ldVR(BI, Cond), BI.getInt32(0), "vm.sl.ib");
 			stVR(BI, Dst, BI.CreateSelect(Bool, TV, FV, "vm.sl.ir"));
-			BI.CreateBr(Dispatch);
+			nextInsn(BI);
 		}
 
 		//  i64 path 
@@ -1301,7 +1301,7 @@ void VMImpl::buildHandlersConv() {
 			Value* FV = ldVR64(B64, rdVR64(B64, IP, 4, "vm.sl.64f"));
 			Value* Bool = B64.CreateICmpNE(ldVR(B64, Cond), B64.getInt32(0), "vm.sl.64b");
 			stVR64(B64, Dst, B64.CreateSelect(Bool, TV, FV, "vm.sl.64r"));
-			B64.CreateBr(Dispatch);
+			nextInsn(B64);
 		}
 	}
 	//  OP_PTRTOINT -- [dst:u8 srcp:u8] 
@@ -1309,7 +1309,7 @@ void VMImpl::buildHandlersConv() {
 		auto B = mkOpc(OP_PTRTOINT, "ptrtoint");
 		Value* IP = advIP(B, 2);
 		Value* Dst = rdVR(B, IP, 0, "vm.pi.d"), * SP = rdPR(B, IP, 1, "vm.pi.s");
-		stVR(B, Dst, B.CreatePtrToInt(ldPR(B, SP), I32Ty, "vm.pi.v")); B.CreateBr(Dispatch);
+		stVR(B, Dst, B.CreatePtrToInt(ldPR(B, SP), I32Ty, "vm.pi.v")); nextInsn(B);
 	}
 
 
@@ -1358,7 +1358,7 @@ void VMImpl::buildHandlersConv() {
 			R = BE.CreateSelect(BE.CreateICmpEQ(Kind, BE.getInt32((uint32_t)C64_SEXT32)), S32, R, "vm.c64.r");
 
 			stVR64(BE, Dst, R);
-			BE.CreateBr(Dispatch);
+			nextInsn(BE);
 		}
 
 		//  trunc path: VR64(i64) -> VR(i32) 
@@ -1381,7 +1381,7 @@ void VMImpl::buildHandlersConv() {
 			R = BT.CreateSelect(BT.CreateICmpEQ(Kind, BT.getInt32((uint32_t)C64_TRUNC32)), T32, R, "vm.c64.tr");
 
 			stVR(BT, Dst, R);
-			BT.CreateBr(Dispatch);
+			nextInsn(BT);
 		}
 	}
 
@@ -1391,7 +1391,7 @@ void VMImpl::buildHandlersConv() {
 		auto B = mkOpc(OP_PTRTOINT64, "ptrtoint64");
 		Value* IP = advIP(B, 2);
 		Value* Dst = rdVR64(B, IP, 0, "vm.pi64.d"), * SP = rdPR(B, IP, 1, "vm.pi64.s");
-		stVR64(B, Dst, B.CreatePtrToInt(ldPR(B, SP), I64Ty, "vm.pi64.v")); B.CreateBr(Dispatch);
+		stVR64(B, Dst, B.CreatePtrToInt(ldPR(B, SP), I64Ty, "vm.pi64.v")); nextInsn(B);
 	}
 
 
@@ -1400,7 +1400,7 @@ void VMImpl::buildHandlersConv() {
 		auto B = mkOpc(OP_INTTOPTR, "inttoptr");
 		Value* IP = advIP(B, 2);
 		Value* DP = rdPR(B, IP, 0, "vm.pp.d"), * Src = rdVR(B, IP, 1, "vm.pp.s");
-		stPR(B, DP, B.CreateIntToPtr(ldVR(B, Src), PtrTy, "vm.pp.v")); B.CreateBr(Dispatch);
+		stPR(B, DP, B.CreateIntToPtr(ldVR(B, Src), PtrTy, "vm.pp.v")); nextInsn(B);
 	}
 
 }
@@ -1411,7 +1411,7 @@ void VMImpl::buildHandlersMem() {
 		auto B = mkOpc(OP_LOAD32, "load32");
 		Value* IP = advIP(B, 2);
 		Value* Dst = rdVR(B, IP, 0, "vm.ld.d"), * PP = rdPR(B, IP, 1, "vm.ld.p");
-		stVR(B, Dst, B.CreateLoad(I32Ty, ldPR(B, PP), "vm.ld.v")); B.CreateBr(Dispatch);
+		stVR(B, Dst, B.CreateLoad(I32Ty, ldPR(B, PP), "vm.ld.v")); nextInsn(B);
 	}
 
 	//  OP_LOAD64 -- [dst64:u8 ptrreg:u8] 
@@ -1419,7 +1419,7 @@ void VMImpl::buildHandlersMem() {
 		auto B = mkOpc(OP_LOAD64, "load64");
 		Value* IP = advIP(B, 2);
 		Value* Dst = rdVR64(B, IP, 0, "vm.ld64.d"), * PP = rdPR(B, IP, 1, "vm.ld64.p");
-		stVR64(B, Dst, B.CreateLoad(I64Ty, ldPR(B, PP), "vm.ld64.v")); B.CreateBr(Dispatch);
+		stVR64(B, Dst, B.CreateLoad(I64Ty, ldPR(B, PP), "vm.ld64.v")); nextInsn(B);
 	}
 
 	//  OP_STORE32 -- [val:u8 ptrreg:u8] 
@@ -1427,7 +1427,7 @@ void VMImpl::buildHandlersMem() {
 		auto B = mkOpc(OP_STORE32, "store32");
 		Value* IP = advIP(B, 2);
 		Value* VR = rdVR(B, IP, 0, "vm.st.v"), * PP = rdPR(B, IP, 1, "vm.st.p");
-		B.CreateStore(ldVR(B, VR), ldPR(B, PP)); B.CreateBr(Dispatch);
+		B.CreateStore(ldVR(B, VR), ldPR(B, PP)); nextInsn(B);
 	}
 
 	//  OP_STORE64 -- [val64:u8 ptrreg:u8] 
@@ -1435,7 +1435,7 @@ void VMImpl::buildHandlersMem() {
 		auto B = mkOpc(OP_STORE64, "store64");
 		Value* IP = advIP(B, 2);
 		Value* VIdx = rdVR64(B, IP, 0, "vm.st64.v"), * PP = rdPR(B, IP, 1, "vm.st64.p");
-		B.CreateStore(ldVR64(B, VIdx), ldPR(B, PP)); B.CreateBr(Dispatch);
+		B.CreateStore(ldVR64(B, VIdx), ldPR(B, PP)); nextInsn(B);
 	}
 
 	//  OP_GEP -- [dstp:u8 basep:u8 idx:u8 elemsz:u16le] 
@@ -1451,7 +1451,7 @@ void VMImpl::buildHandlersMem() {
 		// Byte offset = (i64)idx_value * elemsz
 		Value* IdxVal = B.CreateSExt(ldVR(B, Idx), I64Ty, "vm.gp.iv");
 		Value* ByteOff = B.CreateMul(IdxVal, ESz, "vm.gp.bo");
-		stPR(B, DP, B.CreateGEP(I8Ty, ldPR(B, BP), ByteOff, "vm.gp.v")); B.CreateBr(Dispatch);
+		stPR(B, DP, B.CreateGEP(I8Ty, ldPR(B, BP), ByteOff, "vm.gp.v")); nextInsn(B);
 	}
 
 	//  OP_GEP64 -- [dstp:u8 basep:u8 idx64:u8 elemsz:u16le] 
@@ -1465,7 +1465,7 @@ void VMImpl::buildHandlersMem() {
 		Value* ESz = B.CreateOr(ELo, B.CreateShl(EHi, B.getInt64(8), "vm.gp64.es"), "vm.gp64.esz");
 		Value* IdxVal = ldVR64(B, Idx);
 		Value* ByteOff = B.CreateMul(IdxVal, ESz, "vm.gp64.bo");
-		stPR(B, DP, B.CreateGEP(I8Ty, ldPR(B, BP), ByteOff, "vm.gp64.v")); B.CreateBr(Dispatch);
+		stPR(B, DP, B.CreateGEP(I8Ty, ldPR(B, BP), ByteOff, "vm.gp64.v")); nextInsn(B);
 	}
 
 
@@ -1478,7 +1478,7 @@ void VMImpl::buildHandlersMem() {
 		Value* PP = rdPR(B, IP, 1, "vm.ld8.p");
 		Value* V8 = B.CreateLoad(I8Ty, ldPR(B, PP), "vm.ld8.v");
 		stVR(B, Dst, B.CreateZExt(V8, I32Ty, "vm.ld8.z"));
-		B.CreateBr(Dispatch);
+		nextInsn(B);
 	}
 	{
 		auto B = mkOpc(OP_STORE8, "store8");
@@ -1487,7 +1487,7 @@ void VMImpl::buildHandlersMem() {
 		Value* PP = rdPR(B, IP, 1, "vm.st8.p");
 		Value* V8 = B.CreateTrunc(ldVR(B, VIdx), I8Ty, "vm.st8.t");
 		B.CreateStore(V8, ldPR(B, PP));
-		B.CreateBr(Dispatch);
+		nextInsn(B);
 	}
 	{
 		auto B = mkOpc(OP_LOAD16, "load16");
@@ -1496,7 +1496,7 @@ void VMImpl::buildHandlersMem() {
 		Value* PP = rdPR(B, IP, 1, "vm.ld16.p");
 		Value* V16 = B.CreateLoad(I16Ty, ldPR(B, PP), "vm.ld16.v");
 		stVR(B, Dst, B.CreateZExt(V16, I32Ty, "vm.ld16.z"));
-		B.CreateBr(Dispatch);
+		nextInsn(B);
 	}
 	{
 		auto B = mkOpc(OP_STORE16, "store16");
@@ -1505,7 +1505,7 @@ void VMImpl::buildHandlersMem() {
 		Value* PP = rdPR(B, IP, 1, "vm.st16.p");
 		Value* V16 = B.CreateTrunc(ldVR(B, VIdx), I16Ty, "vm.st16.t");
 		B.CreateStore(V16, ldPR(B, PP));
-		B.CreateBr(Dispatch);
+		nextInsn(B);
 	}
 
 
@@ -1517,7 +1517,7 @@ void VMImpl::buildHandlersMem() {
 		Value* PP = rdPR(B, IP, 1, "vm.lp.p");
 		Value* V = B.CreateLoad(PtrTy, ldPR(B, PP), "vm.lp.v");
 		stPR(B, Dst, V);
-		B.CreateBr(Dispatch);
+		nextInsn(B);
 	}
 	{
 		auto B = mkOpc(OP_STOREPTR, "storeptr");
@@ -1525,7 +1525,7 @@ void VMImpl::buildHandlersMem() {
 		Value* VIdx = rdPR(B, IP, 0, "vm.sp.v");
 		Value* PP = rdPR(B, IP, 1, "vm.sp.p");
 		B.CreateStore(ldPR(B, VIdx), ldPR(B, PP));
-		B.CreateBr(Dispatch);
+		nextInsn(B);
 	}
 
 
@@ -1539,7 +1539,7 @@ void VMImpl::buildHandlersControl() {
 		Value* JT = rdU32(B, IP, 0, "vm.jm.t");
 		if (BlindTargets) JT = B.CreateXor(JT, tgtKeyIR(B, "vm.jm"), "vm.jm.ub");
 		B.CreateStore(JT, VMIP)->setVolatile(true);
-		B.CreateBr(Dispatch);
+		nextInsn(B);
 	}
 
 	//  OP_JMPC -- [cond:u8 tgt_t:u32 tgt_f:u32] 
@@ -1551,7 +1551,7 @@ void VMImpl::buildHandlersControl() {
 		Value* Sel = B.CreateSelect(Bool, Tt, Tf, "vm.jc.s");
 		if (BlindTargets) Sel = B.CreateXor(Sel, tgtKeyIR(B, "vm.jc"), "vm.jc.ub");
 		B.CreateStore(Sel, VMIP)->setVolatile(true);
-		B.CreateBr(Dispatch);
+		nextInsn(B);
 	}
 
 
@@ -1616,7 +1616,7 @@ void VMImpl::buildHandlersControl() {
 		Value* SR = R;
 		if (BlindTargets) SR = DB.CreateXor(R, tgtKeyIR(DB, "vm.sw"), "vm.sw.ub");
 		DB.CreateStore(SR, VMIP)->setVolatile(true);
-		DB.CreateBr(Dispatch);
+		nextInsn(DB);
 	}
 
 
@@ -1707,7 +1707,7 @@ void VMImpl::buildHandlersFloat() {
 		}
 		Value* FV = B.CreateBitCast(Bits, DoubleTy, "vm.lif.v");
 		stFR(B, Dst, FV);
-		B.CreateBr(Dispatch);
+		nextInsn(B);
 	}
 
 	// OP_MOVR_F -- [dst_fr:u8 src_fr:u8]  freg[dst] = freg[src] 
@@ -1715,7 +1715,7 @@ void VMImpl::buildHandlersFloat() {
 		auto B = mkOpc(OP_MOVR_F, "movr_f");
 		Value* IP = advIP(B, 2);
 		stFR(B, rdFR(B, IP, 0, "vm.mrf.d"), ldFR(B, rdFR(B, IP, 1, "vm.mrf.s")));
-		B.CreateBr(Dispatch);
+		nextInsn(B);
 	}
 
 	// OP_BINOP_F -- [dst_fr:u8 a_fr:u8 b_fr:u8 subop:u8] 
@@ -1740,7 +1740,7 @@ void VMImpl::buildHandlersFloat() {
 			Value* Sub8b = B.CreateTrunc(Sub8, I8Ty, "vm.bof.sub8");
 			Value* Rv = B.CreateCall(HelperFn, { AV, BV, Sub8b }, "vm.bof.nested");
 			stFR(B, Dst, Rv);
-			B.CreateBr(Dispatch);
+			nextInsn(B);
 		} else {
 		Value* Sub = B.CreateAnd(Sub8, B.getInt32(0x7F), "vm.bof.sub"); // op only
 		Value* IsF32 = B.CreateICmpNE(
@@ -1765,7 +1765,7 @@ void VMImpl::buildHandlersFloat() {
 			DoubleTy, "vm.bof.ne");
 		Value* Final = FBM.CreateSelect(IsF32M, Narrow, FPhi, "vm.bof.fin");
 		stFR(FBM, Dst, Final);
-		FBM.CreateBr(Dispatch);
+		nextInsn(FBM);
 
 		{
 			IRBuilder<> BD(FDefBB); Value* R = BD.CreateFAdd(AV, BV, "vm.fadd");
@@ -1805,7 +1805,7 @@ void VMImpl::buildHandlersFloat() {
 			Value* Pred8 = B.CreateTrunc(Pred, I8Ty, "vm.fcp.pred8");
 			Value* Rv = B.CreateCall(HelperFn, { AV, BV, Pred8 }, "vm.fcp.nested");
 			stVR(B, Dst, Rv);
-			B.CreateBr(Dispatch);
+			nextInsn(B);
 		} else {
 			using FP = CmpInst::Predicate;
 
@@ -1819,7 +1819,7 @@ void VMImpl::buildHandlersFloat() {
 			IRBuilder<> BM(MergeBB);
 			auto* Phi = BM.CreatePHI(I32Ty, 15, "vm.fcp.r");
 			stVR(BM, Dst, Phi);
-			BM.CreateBr(Dispatch);
+			nextInsn(BM);
 
 			// Default block handles FCMP_FALSE (pred==0): result is always 0.
 			{
@@ -1869,7 +1869,7 @@ void VMImpl::buildHandlersFloat() {
 			B.CreateFPTrunc(SV, Type::getFloatTy(Ctx), "vm.cff.nt"), DoubleTy, "vm.cff.ne");
 		Value* IsExt = B.CreateICmpEQ(Kind, B.getInt32(FK_FPEXT), "vm.cff.ie");
 		stFR(B, Dst, B.CreateSelect(IsExt, SV, Narrow, "vm.cff.r"));
-		B.CreateBr(Dispatch);
+		nextInsn(B);
 	}
 
 	//  OP_FCAST_FV --  [dst_vr:u8 src_fr:u8 kind:u8]  freg→vreg i32  (fptosi / fptoui) 
@@ -1883,7 +1883,7 @@ void VMImpl::buildHandlersFloat() {
 		Value* UI = B.CreateFPToUI(SV, I32Ty, "vm.cfv.ui");
 		Value* IsS = B.CreateICmpEQ(Kind, B.getInt32(FK_FPTOSI), "vm.cfv.is");
 		stVR(B, Dst, B.CreateSelect(IsS, SI, UI, "vm.cfv.r"));
-		B.CreateBr(Dispatch);
+		nextInsn(B);
 	}
 
 	// OP_FCAST_FV64 -- [dst_vr64:u8 src_fr:u8 kind:u8]  freg→vreg64 i64 
@@ -1897,7 +1897,7 @@ void VMImpl::buildHandlersFloat() {
 		Value* UI = B.CreateFPToUI(SV, I64Ty, "vm.cfv64.ui");
 		Value* IsS = B.CreateICmpEQ(Kind, B.getInt32(FK_FPTOSI64), "vm.cfv64.is");
 		stVR64(B, Dst, B.CreateSelect(IsS, SI, UI, "vm.cfv64.r"));
-		B.CreateBr(Dispatch);
+		nextInsn(B);
 	}
 
 	//  OP_FCAST_VF -- [dst_fr:u8 src_vr:u8 kind:u8]  vreg i32→freg  (sitofp / uitofp)
@@ -1919,7 +1919,7 @@ void VMImpl::buildHandlersFloat() {
 			B.CreateFPTrunc(Result, Type::getFloatTy(Ctx), "vm.cvf.nt"),
 			DoubleTy, "vm.cvf.ne");
 		stFR(B, Dst, B.CreateSelect(IsF32, Narrow, Result, "vm.cvf.fin"));
-		B.CreateBr(Dispatch);
+		nextInsn(B);
 	}
 
 	//  OP_FCAST_V64F -- [dst_fr:u8 src_vr64:u8 kind:u8]  vreg64 i64→freg
@@ -1941,7 +1941,7 @@ void VMImpl::buildHandlersFloat() {
 			B.CreateFPTrunc(Result, Type::getFloatTy(Ctx), "vm.cv64f.nt"),
 			DoubleTy, "vm.cv64f.ne");
 		stFR(B, Dst, B.CreateSelect(IsF32, Narrow, Result, "vm.cv64f.fin"));
-		B.CreateBr(Dispatch);
+		nextInsn(B);
 	}
 
 
@@ -1955,7 +1955,7 @@ void VMImpl::buildHandlersFloat() {
 		Value* Dst = rdFR(B, IP, 0, "vm.ldf.d");
 		Value* PP = rdPR(B, IP, 1, "vm.ldf.p");
 		stFR(B, Dst, B.CreateLoad(DoubleTy, ldPR(B, PP), "vm.ldf.v"));
-		B.CreateBr(Dispatch);
+		nextInsn(B);
 	}
 
 	//  OP_STORE_F  [src_fr:u8 ptrreg:u8]    *ptr = freg[src] (f64) 
@@ -1965,7 +1965,7 @@ void VMImpl::buildHandlersFloat() {
 		Value* Src = rdFR(B, IP, 0, "vm.stf.s");
 		Value* PP = rdPR(B, IP, 1, "vm.stf.p");
 		B.CreateStore(ldFR(B, Src), ldPR(B, PP));
-		B.CreateBr(Dispatch);
+		nextInsn(B);
 	}
 
 
@@ -1979,7 +1979,7 @@ void VMImpl::buildHandlersFloat() {
 		Value* PP = rdPR(B, IP, 1, "vm.ldf32.p");
 		Value* F32V = B.CreateLoad(Type::getFloatTy(Ctx), ldPR(B, PP), "vm.ldf32.v");
 		stFR(B, Dst, B.CreateFPExt(F32V, DoubleTy, "vm.ldf32.ext"));
-		B.CreateBr(Dispatch);
+		nextInsn(B);
 	}
 
 	// OP_STORE_F32  [val_fr:u8 ptrreg:u8]  →  *ptr (float*) = fptrunc(freg[val]) 
@@ -1992,7 +1992,7 @@ void VMImpl::buildHandlersFloat() {
 		Value* PP = rdPR(B, IP, 1, "vm.stf32.p");
 		Value* F32V = B.CreateFPTrunc(ldFR(B, Src), Type::getFloatTy(Ctx), "vm.stf32.tr");
 		B.CreateStore(F32V, ldPR(B, PP));
-		B.CreateBr(Dispatch);
+		nextInsn(B);
 	}
 
 	//  OP_RET_F  [src_fr:u8]    return freg[src] 
@@ -2030,7 +2030,7 @@ void VMImpl::buildHandlersFloat() {
 		Value* FV = ldFR(B, rdFR(B, IP, 3, "vm.slf.f"));
 		Value* Bool = B.CreateICmpNE(ldVR(B, Cond), B.getInt32(0), "vm.slf.b");
 		stFR(B, Dst, B.CreateSelect(Bool, TV, FV, "vm.slf.r"));
-		B.CreateBr(Dispatch);
+		nextInsn(B);
 	}
 
 
@@ -2042,7 +2042,7 @@ void VMImpl::buildHandlersFloat() {
 		Value* Dst = rdFR(B, IP, 0, "vm.neg.d");
 		Value* SV = ldFR(B, rdFR(B, IP, 1, "vm.neg.s"));
 		stFR(B, Dst, B.CreateFNeg(SV, "vm.neg.r"));
-		B.CreateBr(Dispatch);
+		nextInsn(B);
 	}
 
 
@@ -2220,7 +2220,7 @@ void VMImpl::buildCall2(VMOp Opc, const Twine& Name, llvm::VMEngine::RetKind2 RK
 		default:      stVR(MB, DstSlot, RetPHI);  break;
 		}
 	}
-	MB.CreateBr(Dispatch);
+	nextInsn(MB);
 }
 
 
@@ -2322,6 +2322,20 @@ void VMImpl::buildHandlerTable() {
 // vm.dispatch: bounds-check IP  vm.fetch: fetch opcode  decrypt  indirectbr
 
 void VMImpl::buildDispatch() {
+	if (ThreadedDispatch) {
+		// No central vm.dispatch/vm.fetch pair: ExitBB and every OpcBB
+		// placeholder were already created before buildOpcodeHandlers() ran
+		// (see populateVMEngine), so every handler's own inlined tail
+		// (nextInsn -> emitThreadedTail) could reference the full successor
+		// set as it was built. All that remains is wiring vm.entry to fetch
+		// the first instruction, same as any other handler's back-edge.
+		if (Entry && !Entry->getTerminator()) {
+			IRBuilder<> EB(Entry);
+			nextInsn(EB);
+		}
+		return;
+	}
+
 	// ExitBB is new; Dispatch is the shell already created in run()
 	ExitBB = BasicBlock::Create(Ctx, "vm.exit", HFn);
 	auto* FetchBB = BasicBlock::Create(Ctx, "vm.fetch", HFn);
@@ -2386,8 +2400,78 @@ void VMImpl::buildDispatch() {
 	}
 
 	// Terminate vm.entry with branch to vm.dispatch
-	if (Entry && !Entry->getTerminator())
-		IRBuilder<>(Entry).CreateBr(Dispatch);
+	if (Entry && !Entry->getTerminator()) {
+		IRBuilder<> EB(Entry);
+		nextInsn(EB);
+	}
+}
+
+// emitThreadedTail / nextInsn
+// threadedDispatch: inline the fetch/decode/indirectbr sequence into every
+// handler's own back-edge instead of routing through one shared vm.dispatch/
+// vm.fetch pair. Mirrors buildDispatch()'s central logic exactly, just
+// emitted per call-site: a bounds check in the caller's current block,
+// followed by a private continuation block holding the fetch/decode/
+// indirectbr. Requires ExitBB and every OpcBB[i][v] to already exist (see
+// populateVMEngine's pre-creation pass) since the first handler built may
+// dispatch to the last one.
+
+void VMImpl::emitThreadedTail(IRBuilder<>& B) {
+	auto* IP = B.CreateLoad(I32Ty, VMIP, "vm.ip.d"); IP->setVolatile(true);
+	Value* BCLen = EffBCLen ? EffBCLen
+		: (Value*)B.getInt32((uint32_t)E.BC.size());
+	Value* OOB = B.CreateICmpUGE(IP, BCLen, "vm.oob");
+
+	BasicBlock* ContBB = BasicBlock::Create(Ctx, "vm.next", HFn);
+	B.CreateCondBr(OOB, ExitBB, ContBB);
+
+	IRBuilder<> FB(ContBB);
+	auto* IP2 = FB.CreateLoad(I32Ty, VMIP, "vm.ip.f"); IP2->setVolatile(true);
+	Value* Raw = loadBC(FB, IP2, 0, "vm.raw");
+
+	// loadBC() already decrypts when EncBytecode=1
+	Value* OpB = Raw;
+
+	// Advance IP past opcode byte
+	FB.CreateStore(FB.CreateAdd(IP2, FB.getInt32(1), "vm.ip1"), VMIP)->setVolatile(true);
+
+	// Clamp opcode index (prevents out-of-bounds GEP on corrupted bytecode)
+	Value* OIdx = FB.CreateZExt(OpB, I32Ty, "vm.oidx");
+	Value* P = FB.CreateURem(OIdx, FB.getInt32(OP_COUNT), "vm.safe");
+
+	// P2: route through the encrypted dispatch map (dmap) when encDispatch
+	// is on -- mirrors buildDispatch()'s vm.fetch logic exactly.
+	Value* FinalSlot;
+	if (EncDispatch) {
+		Value* DmIdx = FB.CreateAdd(P, FB.getInt32(OP_COUNT + 1), "vm.dm.i");
+		Value* DmPtr = FB.CreateGEP(PtrTy, EffHandlers, DmIdx, "vm.dm.p");
+		Value* DmRaw = FB.CreateLoad(PtrTy, DmPtr, "vm.dm.raw");
+		Value* DmInt = FB.CreateTrunc(
+							FB.CreatePtrToInt(DmRaw, I64Ty, "vm.dm.i64"),
+							I32Ty, "vm.dm.i32");
+		auto*  SaltL = FB.CreateLoad(I32Ty, EffSalt, "vm.dm.salt");
+		SaltL->setVolatile(true);
+		Value* Dec   = FB.CreateXor(DmInt, SaltL, "vm.dm.dec");
+		FinalSlot    = FB.CreateURem(Dec, FB.getInt32(OP_COUNT), "vm.dm.slot");
+	} else {
+		FinalSlot = P;
+	}
+
+	// GEP into handler table[final_slot]
+	Value* Slot = FB.CreateGEP(PtrTy, EffHandlers, FinalSlot, "vm.ohsl");
+	Value* Hndl = FB.CreateLoad(PtrTy, Slot, "vm.hndl");
+
+	// indirectbr with all opcode blocks (all variants) declared as successors
+	IndirectBrInst* IBR = FB.CreateIndirectBr(Hndl, OP_COUNT * NumVariants + 1);
+	for (unsigned i = 0; i < OP_COUNT; ++i)
+		for (unsigned v = 0; v < NumVariants; ++v)
+			IBR->addDestination(OpcBB[i][v]);
+	IBR->addDestination(ExitBB);
+}
+
+void VMImpl::nextInsn(IRBuilder<>& B) {
+	if (ThreadedDispatch) emitThreadedTail(B);
+	else B.CreateBr(Dispatch);
 }
 
 
@@ -2847,15 +2931,36 @@ void VMImpl::populateVMEngine() {
 	SS->EngineSalt = SaltAlloca;
 	SS->Entry = Entry;
 
-	// Create Dispatch shell
-	Dispatch = BasicBlock::Create(Ctx, "vm.dispatch", EF);
-	SS->Dispatch = Dispatch;
+	// Create Dispatch shell (central-dispatch builds only; threadedDispatch
+	// has no shared vm.dispatch/vm.fetch pair -- see buildDispatch()).
+	if (!ThreadedDispatch) {
+		Dispatch = BasicBlock::Create(Ctx, "vm.dispatch", EF);
+		SS->Dispatch = Dispatch;
+	}
 
 	// Build all 51 opcode handlers
 	NumVariants = Cfg.handlerVariants;
 	if (NumVariants < 1) NumVariants = 1;
 	if (NumVariants > kMaxHandlerVariants) NumVariants = kMaxHandlerVariants;
 	EncDispatch = Cfg.encDispatch;
+
+	// threadedDispatch: every handler inlines its own fetch/decode/indirectbr
+	// tail (see emitThreadedTail()), which needs the FULL successor set --
+	// every opcode/variant block plus ExitBB -- before any handler body is
+	// built (the first handler emitted may branch to the last one). Pre-create
+	// empty placeholder blocks for all of them up front; mkOpc() fills each in
+	// (renaming, not reallocating) as buildOpcodeHandlers() reaches it.
+	if (ThreadedDispatch) {
+		ExitBB = BasicBlock::Create(Ctx, "vm.exit", EF);
+		new UnreachableInst(Ctx, ExitBB);
+		for (unsigned i = 0; i < OP_COUNT; ++i)
+			for (unsigned v = 0; v < NumVariants; ++v) {
+				BasicBlock* BB = BasicBlock::Create(Ctx, "vm.opc.pending", EF);
+				OpcBB[i][v] = BB;
+				VariantOf[BB] = (uint8_t)v;
+			}
+	}
+
 	buildOpcodeHandlers();
 
 	// Make the K structurally-identical variants distinct (per-variant MBA).
@@ -3005,54 +3110,61 @@ void VMImpl::hardenVMEngine(Function* EF, VMEngine::SharedState* SS) {
 	// Opaque predicates on dispatch + dead code
 	// ════════════════════════════════════════════════════════════════════
 
-	// Dead code blocks
-	// Create 3–5 dead code blocks with junk instructions that branch
-	// back to vm.dispatch (makes CFG look connected).
-	unsigned NDeadBlocks = 3 + HardenRng.range(3); // 3..5
-	SmallVector<BasicBlock*, 8> DeadBBs;
-	for (unsigned i = 0; i < NDeadBlocks; ++i) {
-		auto* DBB = BasicBlock::Create(Ctx, "vm.dead." + Twine(i), EF);
-		IRBuilder<> DB(DBB);
+	// Dead code blocks + opaque predicate on the dispatch back-edge both
+	// require a single shared SS->Dispatch block to branch to / split.
+	// threadedDispatch has no such block (every handler inlines its own
+	// tail) -- both sections are no-ops there. The handler-level MBA above
+	// and the hard-true handler guards below are unaffected and stay active.
+	if (!ThreadedDispatch && SS->Dispatch) {
+		// Dead code blocks
+		// Create 3–5 dead code blocks with junk instructions that branch
+		// back to vm.dispatch (makes CFG look connected).
+		unsigned NDeadBlocks = 3 + HardenRng.range(3); // 3..5
+		SmallVector<BasicBlock*, 8> DeadBBs;
+		for (unsigned i = 0; i < NDeadBlocks; ++i) {
+			auto* DBB = BasicBlock::Create(Ctx, "vm.dead." + Twine(i), EF);
+			IRBuilder<> DB(DBB);
 
-		// Junk arithmetic using opaque constants.
-		Value* J1 = Opaque.opaqueI32Const(DB, HardenRng.u32());
-		Value* J2 = Opaque.opaqueI32Const(DB, HardenRng.u32());
-		Value* R1 = DB.CreateXor(J1, J2, "vm.dead.xor");
-		Value* R2 = DB.CreateMul(R1, J1, "vm.dead.mul");
-		Value* R3 = DB.CreateAdd(R2, J2, "vm.dead.add");
-		(void)R3; // result unused — this is dead code
+			// Junk arithmetic using opaque constants.
+			Value* J1 = Opaque.opaqueI32Const(DB, HardenRng.u32());
+			Value* J2 = Opaque.opaqueI32Const(DB, HardenRng.u32());
+			Value* R1 = DB.CreateXor(J1, J2, "vm.dead.xor");
+			Value* R2 = DB.CreateMul(R1, J1, "vm.dead.mul");
+			Value* R3 = DB.CreateAdd(R2, J2, "vm.dead.add");
+			(void)R3; // result unused — this is dead code
 
-		// Branch back to dispatch (makes block look connected in CFG).
-		DB.CreateBr(SS->Dispatch);
-		DeadBBs.push_back(DBB);
-		++DeadBlocks;
-	}
-
-	// Opaque predicate on vm.dispatch back-edge 
-	// Split vm.dispatch: insert a pre-dispatch block with hard-false
-	// branch to dead code.
-	if (SS->Dispatch && !DeadBBs.empty()) {
-		BasicBlock* DispBB = SS->Dispatch;
-		// Create a new pre-dispatch block.
-		BasicBlock* PreDisp = BasicBlock::Create(Ctx, "vm.predisp", EF, DispBB);
-
-		// Redirect all predecessors of vm.dispatch to vm.predisp.
-		SmallVector<BasicBlock*, 32> Preds(predecessors(DispBB));
-		for (BasicBlock* Pred : Preds) {
-			if (Pred == PreDisp) continue; // skip self
-			Instruction* Term = Pred->getTerminator();
-			if (!Term) continue;
-			for (unsigned i = 0, e = Term->getNumSuccessors(); i < e; ++i) {
-				if (Term->getSuccessor(i) == DispBB)
-					Term->setSuccessor(i, PreDisp);
-			}
+			// Branch back to dispatch (makes block look connected in CFG).
+			DB.CreateBr(SS->Dispatch);
+			DeadBBs.push_back(DBB);
+			++DeadBlocks;
 		}
 
-		// PreDisp: hard-false → dead code, else → real dispatch.
-		IRBuilder<> PB(PreDisp);
-		Value* Fake = Opaque.hardFalse(PB);
-		unsigned DeadIdx = HardenRng.range((uint32_t)DeadBBs.size());
-		PB.CreateCondBr(Fake, DeadBBs[DeadIdx], DispBB);
+		// Opaque predicate on vm.dispatch back-edge
+		// Split vm.dispatch: insert a pre-dispatch block with hard-false
+		// branch to dead code.
+		if (!DeadBBs.empty()) {
+			BasicBlock* DispBB = SS->Dispatch;
+			// Create a new pre-dispatch block.
+			BasicBlock* PreDisp = BasicBlock::Create(Ctx, "vm.predisp", EF, DispBB);
+
+			// Redirect all predecessors of vm.dispatch to vm.predisp.
+			SmallVector<BasicBlock*, 32> Preds(predecessors(DispBB));
+			for (BasicBlock* Pred : Preds) {
+				if (Pred == PreDisp) continue; // skip self
+				Instruction* Term = Pred->getTerminator();
+				if (!Term) continue;
+				for (unsigned i = 0, e = Term->getNumSuccessors(); i < e; ++i) {
+					if (Term->getSuccessor(i) == DispBB)
+						Term->setSuccessor(i, PreDisp);
+				}
+			}
+
+			// PreDisp: hard-false → dead code, else → real dispatch.
+			IRBuilder<> PB(PreDisp);
+			Value* Fake = Opaque.hardFalse(PB);
+			unsigned DeadIdx = HardenRng.range((uint32_t)DeadBBs.size());
+			PB.CreateCondBr(Fake, DeadBBs[DeadIdx], DispBB);
+		}
 	}
 
 	// Hard-true guards on ~30% of handler entries
@@ -3071,14 +3183,15 @@ void VMImpl::hardenVMEngine(Function* EF, VMEngine::SharedState* SS) {
 		BasicBlock* GuardBB = BasicBlock::Create(Ctx,
 			HBB->getName().str() + ".guard", EF, HBB);
 
-		// Create bogus block (junk + branch to dispatch).
+		// Create bogus block (junk + back to dispatch / next-instruction
+		// tail -- nextInsn() picks whichever this build uses).
 		BasicBlock* BogusBB = BasicBlock::Create(Ctx,
 			HBB->getName().str() + ".bogus", EF);
 		{
 			IRBuilder<> BB(BogusBB);
 			Value* J = Opaque.opaqueI32Const(BB, HardenRng.u32());
 			(void)BB.CreateXor(J, J, "vm.bogus.j");
-			BB.CreateBr(SS->Dispatch);
+			nextInsn(BB);
 		}
 
 		// Redirect predecessors of handler to guard block.
@@ -4114,6 +4227,11 @@ void VMImpl::buildCalleeXorCtor() {
 
 void VMImpl::buildAntiDebugGate(VMEngine::SharedState* SS) {
 	if (!Cfg.hardened || !Cfg.antiDebug) return;
+	// threadedDispatch has no central vm.dispatch/vm.fetch pair to insert
+	// this gate between (SS->Dispatch is null there too, so the next check
+	// would already no-op this -- explicit for clarity). The handler-level
+	// spot-check timing traps in hardenVMEngine() still fire independently.
+	if (ThreadedDispatch) return;
 	if (!SS || !SS->EngineFn || !SS->Dispatch || !SS->EngineSalt) return;
 
 	Function* EF = SS->EngineFn;

--- a/VMPass_Impl.cpp
+++ b/VMPass_Impl.cpp
@@ -1900,39 +1900,45 @@ void VMImpl::buildEncryptCtorAES() {
 	// Resolve dangling __strenc_key_a / __strenc_key_b declarations
 	provideStubKeyProviderBodies(M);
 
-	// Create masked expanded-key global 
-	SmallVector<Constant*, 176> MaskedRK;
-	for (int i = 0; i < 176; i++)
-		MaskedRK.push_back(ConstantInt::get(I8Ty, AESExpandedKey[i] ^ AESRKMask[i]));
-
 	auto* RKTy = ArrayType::get(I8Ty, 176);
-	GVAESExpandedKey = new GlobalVariable(
-		M, RKTy, /*isConst=*/true, GlobalValue::PrivateLinkage,
-		ConstantArray::get(RKTy, MaskedRK),
-		(F.getName() + ".vm.aes.rk").str());
-	GVAESExpandedKey->setUnnamedAddr(GlobalValue::UnnamedAddr::Global);
-	GVAESExpandedKey->setAlignment(Align(16));
 
-	// Nonce global (8 bytes, little-endian)
-	SmallVector<Constant*, 8> NonceBytes;
-	for (int i = 0; i < 8; i++)
-		NonceBytes.push_back(ConstantInt::get(I8Ty, (AESNonce >> (8 * i)) & 0xFF));
-	auto* NonceTy = ArrayType::get(I8Ty, 8);
-	GVAESNonce = new GlobalVariable(
-		M, NonceTy, /*isConst=*/true, GlobalValue::PrivateLinkage,
-		ConstantArray::get(NonceTy, NonceBytes),
-		(F.getName() + ".vm.aes.nonce").str());
-	GVAESNonce->setUnnamedAddr(GlobalValue::UnnamedAddr::Global);
+	// Masked expanded-key / nonce / mask globals: when lazyDecrypt is active,
+	// buildWrapper() already created these (it runs before this ctor and
+	// needs them to unmask the key into its own per-call stack context) —
+	// reuse them instead of emitting duplicates. Otherwise create as before.
+	if (!GVAESExpandedKey) {
+		SmallVector<Constant*, 176> MaskedRK;
+		for (int i = 0; i < 176; i++)
+			MaskedRK.push_back(ConstantInt::get(I8Ty, AESExpandedKey[i] ^ AESRKMask[i]));
 
-	// Mask global (used to unmask the expanded key on the stack)
-	SmallVector<Constant*, 176> MaskConsts;
-	for (int i = 0; i < 176; i++)
-		MaskConsts.push_back(ConstantInt::get(I8Ty, AESRKMask[i]));
-	auto* MaskGV = new GlobalVariable(
-		M, RKTy, /*isConst=*/true, GlobalValue::PrivateLinkage,
-		ConstantArray::get(RKTy, MaskConsts),
-		(F.getName() + ".vm.aes.rkmask").str());
-	MaskGV->setUnnamedAddr(GlobalValue::UnnamedAddr::Global);
+		GVAESExpandedKey = new GlobalVariable(
+			M, RKTy, /*isConst=*/true, GlobalValue::PrivateLinkage,
+			ConstantArray::get(RKTy, MaskedRK),
+			(F.getName() + ".vm.aes.rk").str());
+		GVAESExpandedKey->setUnnamedAddr(GlobalValue::UnnamedAddr::Global);
+		GVAESExpandedKey->setAlignment(Align(16));
+
+		// Nonce global (8 bytes, little-endian)
+		SmallVector<Constant*, 8> NonceBytes;
+		for (int i = 0; i < 8; i++)
+			NonceBytes.push_back(ConstantInt::get(I8Ty, (AESNonce >> (8 * i)) & 0xFF));
+		auto* NonceTy = ArrayType::get(I8Ty, 8);
+		GVAESNonce = new GlobalVariable(
+			M, NonceTy, /*isConst=*/true, GlobalValue::PrivateLinkage,
+			ConstantArray::get(NonceTy, NonceBytes),
+			(F.getName() + ".vm.aes.nonce").str());
+		GVAESNonce->setUnnamedAddr(GlobalValue::UnnamedAddr::Global);
+
+		// Mask global (used to unmask the expanded key on the stack)
+		SmallVector<Constant*, 176> MaskConsts;
+		for (int i = 0; i < 176; i++)
+			MaskConsts.push_back(ConstantInt::get(I8Ty, AESRKMask[i]));
+		GVAESRKMask = new GlobalVariable(
+			M, RKTy, /*isConst=*/true, GlobalValue::PrivateLinkage,
+			ConstantArray::get(RKTy, MaskConsts),
+			(F.getName() + ".vm.aes.rkmask").str());
+		GVAESRKMask->setUnnamedAddr(GlobalValue::UnnamedAddr::Global);
+	}
 
 	// Build the .init_array constructor 
 	std::string FnName = (F.getName() + ".vm.ctor").str();
@@ -1966,7 +1972,7 @@ void VMImpl::buildEncryptCtorAES() {
 	IRBuilder<> LB(LoopBody);
 	Value* Idx64 = LB.CreateZExt(Idx, I64Ty);
 	Value* RKPtr = LB.CreateGEP(I8Ty, RKAlloca, Idx64, "vm.ctor.rkp");
-	Value* MkPtr = LB.CreateGEP(I8Ty, MaskGV, Idx64, "vm.ctor.mkp");
+	Value* MkPtr = LB.CreateGEP(I8Ty, GVAESRKMask, Idx64, "vm.ctor.mkp");
 	Value* RKByte = LB.CreateLoad(I8Ty, RKPtr);
 	Value* MkByte = LB.CreateLoad(I8Ty, MkPtr);
 	LB.CreateStore(LB.CreateXor(RKByte, MkByte), RKPtr);
@@ -1979,16 +1985,21 @@ void VMImpl::buildEncryptCtorAES() {
 	AB.CreateMemCpy(GVBytecodeRT, Align(16), GVBytecode, Align(1),
 		ConstantInt::get(I64Ty, BCLen));
 
-	// c) Call __obf_aes_ctr_decrypt(rt_buf, len, rk_stack, nonce_ptr)
-	Value* RTBufPtr = AB.CreateBitCast(GVBytecodeRT, PointerType::getUnqual(Ctx));
-	Value* RKPtr2 = AB.CreateBitCast(RKAlloca, PointerType::getUnqual(Ctx));
-	Value* NoncePtr = AB.CreateBitCast(GVAESNonce, PointerType::getUnqual(Ctx));
-	AB.CreateCall(CTRDecryptFn, {
-		RTBufPtr,
-		ConstantInt::get(I32Ty, BCLen),
-		RKPtr2,
-		NoncePtr
-		});
+	// c) Call __obf_aes_ctr_decrypt(rt_buf, len, rk_stack, nonce_ptr) — strips
+	// the AES layer from the whole runtime buffer up front. Skipped when
+	// LazyDecrypt: the buffer stays ciphertext and the engine's per-byte
+	// fetch (loadBC/loadBCDyn) removes AES one 16-byte block at a time.
+	if (!LazyDecrypt) {
+		Value* RTBufPtr = AB.CreateBitCast(GVBytecodeRT, PointerType::getUnqual(Ctx));
+		Value* RKPtr2 = AB.CreateBitCast(RKAlloca, PointerType::getUnqual(Ctx));
+		Value* NoncePtr = AB.CreateBitCast(GVAESNonce, PointerType::getUnqual(Ctx));
+		AB.CreateCall(CTRDecryptFn, {
+			RTBufPtr,
+			ConstantInt::get(I32Ty, BCLen),
+			RKPtr2,
+			NoncePtr
+			});
+	}
 	AB.CreateRetVoid();
 
 	appendToGlobalCtors(M, CtorFn, 65535, nullptr);
@@ -2029,7 +2040,8 @@ namespace llvm {
 			// Lookup only — returns null if not yet created.
 			// populateVMEngine() handles atomic creation + population.
 			if (Function* Existing = M.getFunction(kVMEngineName)) {
-				assert(Existing->arg_size() == kNumParams &&
+				assert((Existing->arg_size() == kNumParams ||
+					Existing->arg_size() == kNumParams + 1) &&
 					"vm_engine parameter count mismatch");
 				return Existing;
 			}
@@ -2093,6 +2105,7 @@ void VMImpl::setupEffLocal() {
 	EffReg64Keys = nullptr;
 	EffFRegKeys = nullptr;
 	EffCalleeMask = nullptr;  // no callee masking in local mode
+	EffLazyCtx = nullptr;    // local mode never uses lazy AES fetch
 	SharedEngineMode = false;
 }
 
@@ -2108,7 +2121,7 @@ void VMImpl::populateVMEngine() {
 	// anything iterates an empty basic block list.  We create the function
 	// and immediately start adding blocks in the same C++ scope.
 
-	FunctionType* FTy = VMEngine::getVMEngineFunctionType(Ctx);
+	FunctionType* FTy = VMEngine::getVMEngineFunctionType(Ctx, LazyDecrypt);
 	Function* EF = Function::Create(FTy, GlobalValue::InternalLinkage,
 		VMEngine::kVMEngineName, &M);
 
@@ -2126,6 +2139,7 @@ void VMImpl::populateVMEngine() {
 			"handlers", "fty_indices",
 			"regkeys", "reg64keys", "fregkeys",
 			"callee_mask",
+			"lazyctx",
 		};
 		for (Argument& A : EF->args()) A.setName(PNames[PIdx++]);
 	}
@@ -2159,6 +2173,22 @@ void VMImpl::populateVMEngine() {
 	EffReg64Keys = EF->getArg(VMEngine::kParamReg64Keys);
 	EffFRegKeys = EF->getArg(VMEngine::kParamFRegKeys);
 	EffCalleeMask = EF->getArg(VMEngine::kParamCalleeMask);
+	EffLazyCtx = LazyDecrypt ? EF->getArg(VMEngine::kParamLazyCtx) : nullptr;
+
+	// lazyDecrypt: forward-declare the runtime keystream helper so the fetch
+	// path (loadBC/loadBCDyn, built below) can call it. buildEncryptCtorAES()
+	// links the AES stub bitcode (which defines this symbol) later, for the
+	// founding function's own ctor — the linker resolves this declaration
+	// against that definition.
+	if (LazyDecrypt) {
+		KeystreamFn = M.getFunction("__obf_aes_ctr_keystream_block");
+		if (!KeystreamFn) {
+			FunctionType* KSFTy = FunctionType::get(Type::getVoidTy(Ctx),
+				{ PtrTy, PtrTy, I32Ty, PtrTy }, /*isVarArg=*/false);
+			KeystreamFn = Function::Create(KSFTy, GlobalValue::ExternalLinkage,
+				"__obf_aes_ctr_keystream_block", &M);
+		}
+	}
 
 	// Build vm.entry with VMIP + salt alloca
 	Entry = EngEntry;  // already created above
@@ -2189,6 +2219,7 @@ void VMImpl::populateVMEngine() {
 
 	SS->NumVariants = NumVariants;
 	SS->EncDispatch = EncDispatch;
+	SS->LazyMode = LazyDecrypt;
 	for (unsigned i = 0; i < OP_COUNT; ++i)
 		for (unsigned v = 0; v < NumVariants; ++v)
 			SS->OpcBB[i][v] = OpcBB[i][v];
@@ -3037,6 +3068,78 @@ void VMImpl::buildWrapper() {
 	}
 
 
+	// Lazy AES fetch: build the per-call context (unmasked round key + nonce +
+	// keystream-block cache) that the shared engine's loadBC/loadBCDyn use.
+	// Gated on SS->LazyMode (fixed by whichever function founded the shared
+	// engine), not this function's own LazyDecrypt: the wrapper's argument
+	// list must match the already-built engine signature regardless.
+	auto* SS = VMEngine::getSharedState(M);
+	const bool LazyActive = SS->LazyMode;
+	Value* LazyCtxArg = nullptr;
+	if (LazyActive) {
+		// buildWrapper() runs before buildEncryptCtorAES(); when lazy, create
+		// the masked key-schedule/nonce/mask globals here so both this
+		// wrapper and the later ctor (which reuses them instead of
+		// re-emitting) can reference them.
+		if (!GVAESExpandedKey) {
+			SmallVector<Constant*, 176> MaskedRK;
+			for (int i = 0; i < 176; i++)
+				MaskedRK.push_back(ConstantInt::get(I8Ty, AESExpandedKey[i] ^ AESRKMask[i]));
+			auto* RKTy = ArrayType::get(I8Ty, 176);
+			GVAESExpandedKey = new GlobalVariable(
+				M, RKTy, /*isConst=*/true, GlobalValue::PrivateLinkage,
+				ConstantArray::get(RKTy, MaskedRK),
+				(F.getName() + ".vm.aes.rk").str());
+			GVAESExpandedKey->setUnnamedAddr(GlobalValue::UnnamedAddr::Global);
+			GVAESExpandedKey->setAlignment(Align(16));
+
+			SmallVector<Constant*, 8> NonceBytes;
+			for (int i = 0; i < 8; i++)
+				NonceBytes.push_back(ConstantInt::get(I8Ty, (AESNonce >> (8 * i)) & 0xFF));
+			auto* NonceTy = ArrayType::get(I8Ty, 8);
+			GVAESNonce = new GlobalVariable(
+				M, NonceTy, /*isConst=*/true, GlobalValue::PrivateLinkage,
+				ConstantArray::get(NonceTy, NonceBytes),
+				(F.getName() + ".vm.aes.nonce").str());
+			GVAESNonce->setUnnamedAddr(GlobalValue::UnnamedAddr::Global);
+
+			SmallVector<Constant*, 176> MaskConsts;
+			for (int i = 0; i < 176; i++)
+				MaskConsts.push_back(ConstantInt::get(I8Ty, AESRKMask[i]));
+			GVAESRKMask = new GlobalVariable(
+				M, RKTy, /*isConst=*/true, GlobalValue::PrivateLinkage,
+				ConstantArray::get(RKTy, MaskConsts),
+				(F.getName() + ".vm.aes.rkmask").str());
+			GVAESRKMask->setUnnamedAddr(GlobalValue::UnnamedAddr::Global);
+		}
+
+		auto* CtxTy = ArrayType::get(I8Ty, VMEngine::kLazyCtxSize);
+		AllocaInst* LazyCtx = B.CreateAlloca(CtxTy, nullptr, "vm.lazy.ctx");
+		LazyCtx->setAlignment(Align(16));
+
+		// Unmask rk into ctx[0..175] (mirrors buildEncryptCtorAES's stack-unmask).
+		B.CreateMemCpy(LazyCtx, Align(16), GVAESExpandedKey, Align(16), B.getInt64(176));
+		for (unsigned i = 0; i < 176; i++) {
+			Value* Ptr = B.CreateGEP(I8Ty, LazyCtx, B.getInt64(i), "vm.lazy.rk.p");
+			Value* Byte = B.CreateLoad(I8Ty, Ptr, "vm.lazy.rk.b");
+			Value* MkPtr = B.CreateGEP(I8Ty, GVAESRKMask, B.getInt64(i), "vm.lazy.mk.p");
+			Value* Mk = B.CreateLoad(I8Ty, MkPtr, "vm.lazy.mk.b");
+			B.CreateStore(B.CreateXor(Byte, Mk), Ptr);
+		}
+
+		// Copy nonce into ctx[176..183].
+		Value* NonceDst = B.CreateGEP(I8Ty, LazyCtx,
+			B.getInt64(VMEngine::kLazyCtxNonceOff), "vm.lazy.nonce.p");
+		B.CreateMemCpy(NonceDst, Align(1), GVAESNonce, Align(1), B.getInt64(8));
+
+		// cachedBlk = 0xFFFFFFFF: no block cached yet, forces a fetch on first use.
+		Value* CachedBlkPtr = B.CreateGEP(I8Ty, LazyCtx,
+			B.getInt64(VMEngine::kLazyCtxCachedBlkOff), "vm.lazy.cb.p");
+		B.CreateStore(B.getInt32(0xFFFFFFFFu), CachedBlkPtr);
+
+		LazyCtxArg = LazyCtx;
+	}
+
 	// Call vm_engine (indirect via handler table)
 	// the engine pointer is stored in GVHandlers[OP_COUNT].
 	// We load it and make an indirect call.  This eliminates every direct
@@ -3046,7 +3149,7 @@ void VMImpl::buildWrapper() {
 	// Bytecode base: use runtime copy if encryption is enabled
 	Value* BCBase = (EncBytecode && GVBytecodeRT) ? (Value*)GVBytecodeRT : (Value*)GVBytecode;
 
-	Value* Args[VMEngine::kNumParams] = {
+	SmallVector<Value*, VMEngine::kNumParams + 1> Args = {
 		BCBase,                                                          // bc
 		blindI32((uint32_t)E.BC.size()),                                 // bc_len
 		WRegs,                                                           // regs
@@ -3073,13 +3176,14 @@ void VMImpl::buildWrapper() {
 		// per-function callee XOR mask (0 when unhardened)
 		VCtx.Cfg.hardened ? blindI64(CalleeMask) : B.getInt64(0),       // callee_mask
 	};
+	if (LazyActive) Args.push_back(LazyCtxArg);              // lazyctx
 
 	// Load engine function pointer from handler table slot [OP_COUNT]
 	Value* EngSlot = B.CreateGEP(PtrTy, GVHandlers,
 		blindI32(OP_COUNT), "vm.eng.slot");
 	Value* EngPtr = B.CreateLoad(PtrTy, EngSlot, "vm.eng.ptr");
 
-	FunctionType* EngFTy = VMEngine::getVMEngineFunctionType(Ctx);
+	FunctionType* EngFTy = VMEngine::getVMEngineFunctionType(Ctx, LazyActive);
 	B.CreateCall(EngFTy, EngPtr, Args);
 
 	// Extract return value and return

--- a/VMPass_Impl.cpp
+++ b/VMPass_Impl.cpp
@@ -2361,6 +2361,14 @@ void VMImpl::buildDispatch() {
 		// loadBC() already decrypts when EncBytecode=1
 		Value* OpB = Raw;
 
+		// keyedDispatch: un-XOR the per-IP opcode key applied by
+		// BytecodeEmitter::bop() at write time, before mapping the byte to a
+		// permuted opcode index.
+		if (KeyedDispatch) {
+			auto* SaltL = B.CreateLoad(I32Ty, EffSalt, "vm.opk.salt"); SaltL->setVolatile(true);
+			OpB = B.CreateXor(OpB, opKeyByteIR(B, SaltL, IP, "vm.opk"), "vm.opd");
+		}
+
 		// Advance IP past opcode byte
 		B.CreateStore(B.CreateAdd(IP, B.getInt32(1), "vm.ip1"), VMIP)->setVolatile(true);
 
@@ -2431,6 +2439,14 @@ void VMImpl::emitThreadedTail(IRBuilder<>& B) {
 
 	// loadBC() already decrypts when EncBytecode=1
 	Value* OpB = Raw;
+
+	// keyedDispatch: un-XOR the per-IP opcode key applied by
+	// BytecodeEmitter::bop() at write time, before mapping the byte to a
+	// permuted opcode index. Mirrors buildDispatch()'s vm.fetch logic exactly.
+	if (KeyedDispatch) {
+		auto* SaltL = FB.CreateLoad(I32Ty, EffSalt, "vm.opk.salt"); SaltL->setVolatile(true);
+		OpB = FB.CreateXor(OpB, opKeyByteIR(FB, SaltL, IP2, "vm.opk"), "vm.opd");
+	}
 
 	// Advance IP past opcode byte
 	FB.CreateStore(FB.CreateAdd(IP2, FB.getInt32(1), "vm.ip1"), VMIP)->setVolatile(true);
@@ -4952,6 +4968,7 @@ bool VMImpl::run() {
 	E.setOpcodeMap(&OpMap);
 	E.setTargetBlind(SaltConst, BlindTargets);
 	E.setConstInStream(ConstInStream);
+	E.setKeyedDispatch(SaltConst, KeyedDispatch);
 	if (!E.run(F, CTSalt, M.getDataLayout())) {
 		FailReason = E.getFailReason().str();
 		if (FailReason.empty()) FailReason = "bytecode emission failed";
@@ -4961,7 +4978,7 @@ bool VMImpl::run() {
 	if (ObfVerify) {
 		std::string VErr;
 		uint32_t BadIP = 0;
-		if (!verifyBytecode(E, CTSalt, OpMap, VErr, BadIP, SaltConst, BlindTargets)) {
+		if (!verifyBytecode(E, CTSalt, OpMap, VErr, BadIP, SaltConst, BlindTargets, KeyedDispatch)) {
 			FailReason = ("bytecode verify failed at ip " + std::to_string(BadIP) + ": " + VErr);
 			return false;
 		}

--- a/VMPass_Verifier.cpp
+++ b/VMPass_Verifier.cpp
@@ -15,8 +15,16 @@ namespace llvm {
 
 	bool verifyBytecode(const BytecodeEmitter& E, uint8_t CTSalt, const VMOpcodeMap& OpMap,
 		std::string& OutErr, uint32_t& OutBadIP,
-		uint32_t SaltFull, bool BlindTargets) {
+		uint32_t SaltFull, bool BlindTargets, bool KeyedDispatch) {
 		const auto& BC = E.BC;
+
+		// keyedDispatch: mirrors BytecodeEmitter::opKeyByteCT / VMImpl::opKeyByteIR
+		// op-for-op so the opcode byte at each IP is un-XOR'd the same way the
+		// runtime fetch path does before it is looked up in OpMap.P2L.
+		auto opKeyByteCT = [](uint32_t salt, uint32_t ip) -> uint8_t {
+			uint32_t k = (salt * (ip + 1u)) ^ (salt >> 8);
+			return (uint8_t)(k & 0xFFu);
+			};
 
 		// P3-B: branch targets are stored XOR-blinded with tgtKey(SaltFull).
 		// Mirror BytecodeEmitter::tgtKeyCT / VMImpl::tgtKeyIR so chkTarget can
@@ -131,6 +139,7 @@ namespace llvm {
 		uint32_t IP = 0;
 		while (IP < BC.size()) {
 			uint8_t Phys = BC[IP];
+			if (KeyedDispatch) Phys ^= opKeyByteCT(SaltFull, IP);
 			if (Phys >= OP_COUNT)
 				return fail(IP, Twine("invalid opcode byte ") + Twine((unsigned)Phys));
 

--- a/VMPass_Verifier.cpp
+++ b/VMPass_Verifier.cpp
@@ -141,6 +141,11 @@ namespace llvm {
 				if (!chk(IP, "vreg", decIdx(BC[IP + 1]), E.NVR)) return false;
 				IP += 6; break;
 			}
+			case OP_LOADI64: {
+				if (IP + 10 > BC.size()) return fail(IP, "OP_LOADI64 truncated");
+				if (!chk(IP, "vreg64", decIdx(BC[IP + 1]), E.NVR64)) return false;
+				IP += 10; break;
+			}
 			case OP_MOVR: {
 				if (IP + 3 > BC.size()) return fail(IP, "OP_MOVR truncated");
 				if (!chk(IP, "vreg", decIdx(BC[IP + 1]), E.NVR)) return false;

--- a/aes_stub/aes_stub.c
+++ b/aes_stub/aes_stub.c
@@ -4,6 +4,7 @@
  * Public entry points:
  *   __aes_decrypt()       — used by strenc (reconstructs key from providers)
  *   __obf_aes_ctr_decrypt()  — used by vmpass (caller supplies expanded key)
+ *   __obf_aes_ctr_keystream_block() — used by vmpass lazyDecrypt (single-block keystream)
  *   __strenc_chacha_decrypt() — used by strenc's ChaCha20 (cipher=chacha) path
  *
  * Both passes link this same bitcode; the linker-level dedup check in
@@ -195,6 +196,35 @@ void __obf_aes_ctr_decrypt(uint8_t *buf, uint32_t len,
         offset += 16u;
         ctr_inc(ctr);
     }
+}
+
+
+/*
+* __obf_aes_ctr_keystream_block  —  Single AES-CTR keystream block.
+*
+* Produces the 16-byte keystream block for a given block index without
+* touching any plaintext/ciphertext buffer. Used by vmpass lazyDecrypt to
+* remove the AES layer for one bytecode byte at a time instead of decrypting
+* the whole buffer up front.
+*
+* rk176   : pointer to the full 176-byte expanded AES-128 round-key schedule.
+* nonce8  : 8-byte nonce; counter block = nonce8 || 0x00000000 || block_be32.
+* block   : block index (matches vm_aes::ctr's per-16-byte counter).
+* out16   : receives the 16-byte keystream block.
+*/
+__attribute__((noinline))
+void __obf_aes_ctr_keystream_block(const uint8_t *rk176, const uint8_t *nonce8,
+                                    uint32_t block, uint8_t out16[16]) {
+    uint8_t ctr[16];
+    se_memcpy(ctr, nonce8, 8);
+    ctr[8] = 0; ctr[9] = 0; ctr[10] = 0; ctr[11] = 0;
+    ctr[12] = (uint8_t)(block >> 24);
+    ctr[13] = (uint8_t)(block >> 16);
+    ctr[14] = (uint8_t)(block >> 8);
+    ctr[15] = (uint8_t)(block);
+
+    se_memcpy(out16, ctr, 16);
+    aes128_encrypt_block(rk176, out16);
 }
 
 

--- a/include/llvm/Transforms/Obfuscator/ObfuscationConfig.h
+++ b/include/llvm/Transforms/Obfuscator/ObfuscationConfig.h
@@ -279,6 +279,7 @@ namespace llvm {
 		unsigned minBlocks = 1;
 		unsigned maxBlocks = 400;     // 0 = no limit
 		bool     useAES = true;       // AES-CTR replaces LCG (Layer 2)
+		bool     lazyDecrypt = false; // AES layer removed per-instruction at fetch instead of whole-buffer in ctor (requires useAES + encBytecode)
 		bool     obfRegIdx = true;    // XOR register indices with compile-time salt
 		bool     encDispatch = true;   // P2: encrypted per-opcode->handler index indirection (on)
 		unsigned handlerVariants = 3;  // K handler-body variants per opcode (P1 polymorphism on; 1 = off)

--- a/include/llvm/Transforms/Obfuscator/ObfuscationConfig.h
+++ b/include/llvm/Transforms/Obfuscator/ObfuscationConfig.h
@@ -310,6 +310,12 @@ namespace llvm {
 		// indirectbr). Off = byte-identical to the central-dispatch build.
 		bool     threadedDispatch = false;
 
+		// keyedDispatch: XOR each written opcode byte with a per-IP compile-time
+		// key at emit time; un-XOR at fetch time. The same physical byte read
+		// from two different IPs decodes to different logical opcodes, so a
+		// static byte->handler map no longer holds. Off = byte-identical.
+		bool     keyedDispatch = false;
+
 		static VMPassConfig fromPassConfig(const PassConfig& PC);
 		bool validate() const;
 	};

--- a/include/llvm/Transforms/Obfuscator/ObfuscationConfig.h
+++ b/include/llvm/Transforms/Obfuscator/ObfuscationConfig.h
@@ -297,6 +297,12 @@ namespace llvm {
 		unsigned adDispatchInterval = 64;    // check every N fetch iterations (power of 2)
 		unsigned adHandlerProb = 10;    // % of handlers to trap (0-100)
 
+		bool     nestedVM = false;         // virtualize eligible opcode handlers with a second VM layer
+		// 0 = all eligible opcodes nest; N>0 = only the first N, in the fixed
+		// order BINOP, BINOP64, ICMP, ICMP64, FCMP, CAST (see kNestedHelperOrder).
+		unsigned nestedVMOpcodes = 0;
+		bool     nestedVMHardened = false; // reserved: harden the inner VM layer (unused)
+
 		static VMPassConfig fromPassConfig(const PassConfig& PC);
 		bool validate() const;
 	};

--- a/include/llvm/Transforms/Obfuscator/ObfuscationConfig.h
+++ b/include/llvm/Transforms/Obfuscator/ObfuscationConfig.h
@@ -284,6 +284,7 @@ namespace llvm {
 		bool     encDispatch = true;   // P2: encrypted per-opcode->handler index indirection (on)
 		unsigned handlerVariants = 3;  // K handler-body variants per opcode (P1 polymorphism on; 1 = off)
 		bool     encBytecode = true;  // LCG-encrypt bytecode stream at load time
+		bool     constInStream = false;  // move int/i64/fp constants into the encrypted bytecode stream instead of plaintext wrapper stores (requires encBytecode)
 		bool     strongBytecode = true;   // P3: per-position PRF Layer-1 keystream (on; 0 = weak salt^index)
 		bool     blindTargets = true;   // P3: XOR-blind bytecode branch targets (on)
 		bool     hardened = false;    // MBA + opaque predicates on handler blocks

--- a/include/llvm/Transforms/Obfuscator/ObfuscationConfig.h
+++ b/include/llvm/Transforms/Obfuscator/ObfuscationConfig.h
@@ -303,6 +303,13 @@ namespace llvm {
 		unsigned nestedVMOpcodes = 0;
 		bool     nestedVMHardened = false; // reserved: harden the inner VM layer (unused)
 
+		// threadedDispatch: inline the fetch/decode/indirectbr sequence into
+		// every handler's back-edge instead of routing through one shared
+		// vm.dispatch/vm.fetch pair. Removes the single central dispatch loop
+		// a lifter would otherwise fingerprint (one urem, one GEP, one
+		// indirectbr). Off = byte-identical to the central-dispatch build.
+		bool     threadedDispatch = false;
+
 		static VMPassConfig fromPassConfig(const PassConfig& PC);
 		bool validate() const;
 	};

--- a/include/llvm/Transforms/Obfuscator/VMPass_Emitter.h
+++ b/include/llvm/Transforms/Obfuscator/VMPass_Emitter.h
@@ -113,6 +113,10 @@ namespace llvm {
 		/// leaving it for the wrapper's plaintext preload stores.
 		void setConstInStream(bool on) { ConstInStream = on; }
 
+		/// keyedDispatch: XOR each written opcode byte with a per-IP compile-time
+		/// key derived from saltFull (see opKeyByteCT); on is the knob.
+		void setKeyedDispatch(uint32_t saltFull, bool on) { KeyedSalt = saltFull; KeyedDispatch = on; }
+
 		/// Compile F into bytecode.  Salt is the CTSalt byte used to XOR register
 		/// index bytes (0 when obfRegIdx is disabled).
 		/// Returns false on failure; FailReason is populated.
@@ -125,6 +129,21 @@ namespace llvm {
 		uint32_t           SaltFull = 0;
 		bool               BlindTargets = false;
 		bool               ConstInStream = false;
+		uint32_t           KeyedSalt = 0;
+		bool               KeyedDispatch = false;
+		// keyedDispatch: pre-splice IP of every opcode byte written by bop(), in
+		// emission order. Consumed by the constInStream prologue-splice step in
+		// run() to re-key body opcode bytes once their final (post-splice) IP is
+		// known; unused (and left empty) otherwise.
+		SmallVector<uint32_t, 64> KeyedOpIPs;
+
+		// keyedDispatch: per-IP opcode-byte XOR key mix. Mirrors VMImpl::opKeyByteIR
+		// op-for-op and is duplicated verbatim in verifyBytecode() (VMPass_Verifier.cpp)
+		// so all three sites decode the same physical byte the same way.
+		static uint8_t opKeyByteCT(uint32_t salt, uint32_t ip) {
+			uint32_t k = (salt * (ip + 1u)) ^ (salt >> 8);
+			return (uint8_t)(k & 0xFFu);
+		}
 
 		// P3-B: compile-time branch-target blinding key mix. Mirrors VMImpl::tgtKeyIR
 		// op-for-op; distinct constants from ksByteCT (Layer-1 keystream) so the two
@@ -317,7 +336,23 @@ namespace llvm {
 		// ── Bytecode emission primitives ──────────────────────────────────────
 
 		uint8_t encOp(VMOp Op) const { return OpMap ? OpMap->encode(Op) : (uint8_t)Op; }
-		void bop(VMOp Op) { b8(encOp(Op)); }
+		void bop(VMOp Op) {
+			uint8_t v = encOp(Op);
+			// keyedDispatch: K(IP) is baked in using ip() as it stands right now.
+			// When constInStream later splices a prologue in front of the
+			// already-emitted body, every body opcode byte's final position moves
+			// by PrologueLen -- the baked-in mask no longer matches. Record this
+			// byte's pre-splice IP so run()'s constInStream block can re-key it
+			// once the real final position is known (see the KeyedOpIPs walk
+			// there). Prologue opcodes are written after the splice point is
+			// decided, so their ip() is already final and never need correcting.
+			if (KeyedDispatch) {
+				uint32_t IP = ip();
+				v ^= opKeyByteCT(KeyedSalt, IP);
+				KeyedOpIPs.push_back(IP);
+			}
+			b8(v);
+		}
 
 		void     b8(uint8_t v) { BC.push_back(v); }
 		void     u16(uint16_t v) { b8(v & 0xFF); b8(v >> 8); }

--- a/include/llvm/Transforms/Obfuscator/VMPass_Emitter.h
+++ b/include/llvm/Transforms/Obfuscator/VMPass_Emitter.h
@@ -108,6 +108,11 @@ namespace llvm {
 		/// per-function salt (SaltConst); on is the blindTargets knob.
 		void setTargetBlind(uint32_t saltFull, bool on) { SaltFull = saltFull; BlindTargets = on; }
 
+		/// Move int/i64/fp constant slot seeding into the encrypted bytecode
+		/// stream (as an OP_LOADI*/OP_LOADI64/OP_LOADI_F prologue) instead of
+		/// leaving it for the wrapper's plaintext preload stores.
+		void setConstInStream(bool on) { ConstInStream = on; }
+
 		/// Compile F into bytecode.  Salt is the CTSalt byte used to XOR register
 		/// index bytes (0 when obfRegIdx is disabled).
 		/// Returns false on failure; FailReason is populated.
@@ -119,6 +124,7 @@ namespace llvm {
 		const VMOpcodeMap* OpMap = nullptr;
 		uint32_t           SaltFull = 0;
 		bool               BlindTargets = false;
+		bool               ConstInStream = false;
 
 		// P3-B: compile-time branch-target blinding key mix. Mirrors VMImpl::tgtKeyIR
 		// op-for-op; distinct constants from ksByteCT (Layer-1 keystream) so the two
@@ -316,6 +322,7 @@ namespace llvm {
 		void     b8(uint8_t v) { BC.push_back(v); }
 		void     u16(uint16_t v) { b8(v & 0xFF); b8(v >> 8); }
 		void     u32(uint32_t v) { b8(v); b8(v >> 8); b8(v >> 16); b8(v >> 24); }
+		void     u64(uint64_t v) { u32((uint32_t)v); u32((uint32_t)(v >> 32)); }
 		uint32_t ip() const { return (uint32_t)BC.size(); }
 
 		/// [Step 01.1] Emit an f64 value as 8 bytes, little-endian IEEE-754.

--- a/include/llvm/Transforms/Obfuscator/VMPass_ISA.h
+++ b/include/llvm/Transforms/Obfuscator/VMPass_ISA.h
@@ -104,7 +104,9 @@ namespace llvm {
 		OP_FCAST_FV64 = 0x30,  // freg  → vreg64 i64 : FK_FPTOSI64 / FK_FPTOUI64
 		OP_FCAST_VF = 0x31,  // vreg  i32  → freg  : FK_SITOFP   / FK_UITOFP
 		OP_FCAST_V64F = 0x32,  // vreg64 i64 → freg  : FK_SI64TOFP / FK_UI64TOFP
-		OP_COUNT = 0x33
+
+		OP_LOADI64 = 0x33,  // dst64:u8 imm:i64le  (1+1+8 = 10 bytes)
+		OP_COUNT = 0x34
 	};
 
 	// Max handler-body variants per opcode in the shared __vm_engine.

--- a/include/llvm/Transforms/Obfuscator/VMPass_Impl.h
+++ b/include/llvm/Transforms/Obfuscator/VMPass_Impl.h
@@ -251,6 +251,7 @@ namespace llvm {
 		const bool     LazyDecrypt;  // AES layer removed per-instruction at fetch instead of whole-buffer in ctor
 		const bool     RegEncrypt;   // XOR-encrypt register values at rest
 		const bool     RollingRegKey; // P4-C: evolve per-slot reg XOR key on each store
+		const bool     ConstInStream; // move int/i64/fp constants into the encrypted bytecode stream instead of plaintext wrapper stores
 		const uint32_t SaltConst;    // full 32-bit salt stored in vm.salt
 		const uint8_t  CTSalt;       // low byte of SaltConst must match deobf() key
 		const uint64_t EncSeed;      // seed for bytecode LCG encryption
@@ -383,6 +384,7 @@ namespace llvm {
 			LazyDecrypt(VCtx.Cfg.lazyDecrypt),
 			RegEncrypt(VCtx.Cfg.regEncrypt),
 			RollingRegKey(VCtx.Cfg.rollingRegKey),
+			ConstInStream(VCtx.Cfg.constInStream),
 			SaltConst(VCtx.R.u32()),
 			// IMPORTANT: indices are only XOR-salted when obfRegIdx=1.
 			// When obfRegIdx=0, emitter must write raw indices (CTSalt=0).

--- a/include/llvm/Transforms/Obfuscator/VMPass_Impl.h
+++ b/include/llvm/Transforms/Obfuscator/VMPass_Impl.h
@@ -287,6 +287,7 @@ namespace llvm {
 		const bool     NestedVM;         // eligible opcode handlers call a second VM-interpreted layer instead of computing inline
 		const unsigned NestedVMOpcodes;  // 0 = all eligible opcodes nest; N>0 = first N in the fixed order (see opcodeNests)
 		const bool     NestedVMHardened; // reserved: harden the inner VM layer
+		const bool     ThreadedDispatch; // inline fetch/decode/indirectbr into every handler's back-edge; no central vm.dispatch/vm.fetch
 		// Which shared engine this build targets: 0 = plain ("__vm_engine"),
 		// 1 = nesting ("__vm_engine.nest"). Derived from NestedVM, not an
 		// independent knob -- a nestedVM=true build always wants the engine
@@ -436,6 +437,7 @@ namespace llvm {
 			NestedVM(Cfg.nestedVM),
 			NestedVMOpcodes(Cfg.nestedVMOpcodes),
 			NestedVMHardened(Cfg.nestedVMHardened),
+			ThreadedDispatch(Cfg.threadedDispatch),
 			EngineId(NestedVM ? 1u : 0u),
 			SaltConst(R.u32()),
 			// IMPORTANT: indices are only XOR-salted when obfRegIdx=1.
@@ -719,8 +721,17 @@ namespace llvm {
 			St->setVolatile(true); return Cur;
 		}
 
-		// Build one opcode handler block and return an IRBuilder positioned in it
+		// Build one opcode handler block and return an IRBuilder positioned in it.
+		// threadedDispatch pre-creates every OpcBB[Opc][variant] placeholder
+		// before any handler body is built (each handler's inlined dispatch
+		// tail needs the full successor set up front) -- reuse and rename that
+		// block instead of allocating a fresh one. Off path unchanged.
 		IRBuilder<> mkOpc(VMOp Opc, const Twine& Name) {
+			if (ThreadedDispatch && OpcBB[Opc][CurVariant]) {
+				BasicBlock* BB = OpcBB[Opc][CurVariant];
+				BB->setName("vm.opc." + Name + ".v" + Twine(CurVariant));
+				return IRBuilder<>(BB);
+			}
 			BasicBlock* BB = BasicBlock::Create(Ctx,
 				"vm.opc." + Name + ".v" + Twine(CurVariant), HFn);
 			OpcBB[Opc][CurVariant] = BB; return IRBuilder<>(BB);
@@ -774,6 +785,17 @@ namespace llvm {
 
 		void buildHandlerTable();   // must come AFTER buildOpcodeHandlers
 		void buildDispatch();       // must come AFTER buildHandlerTable
+
+		// threadedDispatch: emits the fetch/decode/indirectbr sequence inline
+		// at B's current insertion point (bounds check -> ExitBB; otherwise
+		// load+advance IP, decode opcode, indirectbr to the target handler).
+		// Terminates B's current block; callers must not emit after calling
+		// this. Mirrors buildDispatch()'s vm.fetch logic exactly.
+		void emitThreadedTail(IRBuilder<>& B);
+
+		// Handler back-edge dispatch: central Dispatch branch when
+		// !ThreadedDispatch, inlined threaded tail otherwise.
+		void nextInsn(IRBuilder<>& B);
 		void buildEncryptCtor();    // optional encryption constructor
 		void buildEncryptCtorAES(); // Step 03: AES-CTR constructor
 		void buildEncryptCtorLCG(); // Legacy LCG constructor (useAES=0)

--- a/include/llvm/Transforms/Obfuscator/VMPass_Impl.h
+++ b/include/llvm/Transforms/Obfuscator/VMPass_Impl.h
@@ -763,6 +763,7 @@ namespace llvm {
 		Function* getOrCreateNestedIcmp64Helper();  // idempotent per module
 		Function* getOrCreateNestedFcmpHelper();    // idempotent per module
 		Function* getOrCreateNestedCastHelper();    // idempotent per module
+		Function* getOrCreateNestedBinopFHelper();  // idempotent per module
 		Function* getOrCreateNestedHelper(VMOp Op); // dispatches to the per-opcode authors above
 		void virtualizeNestedHelpersOnce();         // idempotent per module
 

--- a/include/llvm/Transforms/Obfuscator/VMPass_Impl.h
+++ b/include/llvm/Transforms/Obfuscator/VMPass_Impl.h
@@ -166,6 +166,21 @@ namespace llvm {
 		/// The well-known symbol name for the shared engine function.
 		static constexpr const char* kVMEngineName = "__vm_engine";
 
+		/// Nested-VM: a second, distinct engine function for builds whose
+		/// OP_BINOP calls into the inner-virtualized helper. Keeping it a
+		/// SEPARATE function (not a runtime flag on the same engine) is what
+		/// breaks the recursion: the helper is itself virtualized against
+		/// EngineId 0 (the plain engine, computes OP_BINOP inline), so its
+		/// bytecode's own binops never call back into the helper.
+		static constexpr const char* kVMEngineNestName = "__vm_engine.nest";
+
+		/// EngineId 0 -> plain engine ("__vm_engine"), 1 -> nesting engine
+		/// ("__vm_engine.nest"). Selects both the SharedState instance and the
+		/// emitted Function's symbol name.
+		inline const char* vmEngineName(unsigned EngineId) {
+			return EngineId ? kVMEngineNestName : kVMEngineName;
+		}
+
 		/// Return the canonical FunctionType for vm_engine. `lazy` appends the
 		/// trailing lazyctx ptr param; false (default) reproduces the exact
 		/// pre-existing signature.
@@ -186,8 +201,9 @@ namespace llvm {
 			return FunctionType::get(VoidTy, ArrayRef<Type*>(Params, N), /*isVarArg=*/false);
 		}
 
-		/// Get or create the module-level @__vm_engine function.
-		Function* getOrBuildVMEngine(Module& M);
+		/// Get or create the module-level @__vm_engine (EngineId 0) or
+		/// @__vm_engine.nest (EngineId 1) function.
+		Function* getOrBuildVMEngine(Module& M, unsigned EngineId = 0);
 
 		/// Check whether the vm_engine body has been populated with handlers.
 		bool isEnginePopulated(Function* VMEngineFunc);
@@ -227,10 +243,19 @@ namespace llvm {
 
 			bool Populated = false;
 			unsigned FTyCountAtLastBuild = 0;
+
+			// nested-VM: set once the module-level pure opcode helper(s) have been
+			// inner-virtualized, so later functions' VMImpl::run() don't repeat it.
+			bool NestedHelpersBuilt = false;
 		};
 
-		SharedState* getSharedState(Module& M);
-		void releaseSharedState(Module& M);
+		// EngineId selects which of the (at most two) shared engines' state to
+		// return: 0 = plain engine, 1 = nesting engine. Each is built/populated
+		// independently (independent "first function" guard), so a nesting-
+		// engine build never observes or perturbs the plain engine's state
+		// and vice versa. Default (0) reproduces pre-nestedVM behavior exactly.
+		SharedState* getSharedState(Module& M, unsigned EngineId = 0);
+		void releaseSharedState(Module& M);  // clears state for every EngineId of M
 
 	} // namespace VMEngine
 
@@ -240,8 +265,15 @@ namespace llvm {
 		Module& M;
 		LLVMContext& Ctx;
 		Type* I8Ty, * I16Ty, * I32Ty, * I64Ty, * PtrTy;
-		Type* DoubleTy;  // f64 type — used by float handler builders 
-		VMCtx& VCtx;
+		Type* DoubleTy;  // f64 type — used by float handler builders
+
+		// Config + RNG are owned/referenced directly (not via VMCtx) so VMImpl
+		// can be constructed either from the annotation-driven VMCtx (normal
+		// per-function path) or from an explicit config+RNG (synthetic helper
+		// functions authored by the pass itself, e.g. nested-VM helpers, which
+		// have no FunctionObfContext / annotation of their own).
+		VMPassConfig Cfg;
+		obf::Rng&    R;
 
 		const bool     ObfRegIdx;
 		const bool     EncBytecode;
@@ -252,6 +284,15 @@ namespace llvm {
 		const bool     RegEncrypt;   // XOR-encrypt register values at rest
 		const bool     RollingRegKey; // P4-C: evolve per-slot reg XOR key on each store
 		const bool     ConstInStream; // move int/i64/fp constants into the encrypted bytecode stream instead of plaintext wrapper stores
+		const bool     NestedVM;         // eligible opcode handlers call a second VM-interpreted layer instead of computing inline
+		const unsigned NestedVMOpcodes;  // 0 = all eligible opcodes nest; N>0 = first N in the fixed order (see opcodeNests)
+		const bool     NestedVMHardened; // reserved: harden the inner VM layer
+		// Which shared engine this build targets: 0 = plain ("__vm_engine"),
+		// 1 = nesting ("__vm_engine.nest"). Derived from NestedVM, not an
+		// independent knob -- a nestedVM=true build always wants the engine
+		// whose OP_BINOP calls the helper; nestedVM=false (including the
+		// helper's own inner-virtualization) always wants the plain one.
+		const unsigned EngineId;
 		const uint32_t SaltConst;    // full 32-bit salt stored in vm.salt
 		const uint8_t  CTSalt;       // low byte of SaltConst must match deobf() key
 		const uint64_t EncSeed;      // seed for bytecode LCG encryption
@@ -367,44 +408,55 @@ namespace llvm {
 			unsigned P = 1; while (P < N) P <<= 1; return P;
 		}
 
-		explicit VMImpl(VMCtx& VCtx)
-			: F(VCtx.F), M(*VCtx.F.getParent()), Ctx(VCtx.F.getContext()),
+		// Normal per-function path: config + RNG come from the annotation-driven
+		// VMCtx (FunctionObfContextAnalysis-backed).
+		explicit VMImpl(VMCtx& VCtx) : VMImpl(VCtx.F, VCtx.Cfg, VCtx.R) {}
+
+		// Synthetic-function path: explicit config + RNG, no VMCtx/annotation.
+		// Used to virtualize compiler-authored helper functions (e.g. nested-VM
+		// opcode helpers) that have no FunctionObfContext of their own.
+		VMImpl(Function& Fn, const VMPassConfig& CfgIn, obf::Rng& RIn)
+			: F(Fn), M(*Fn.getParent()), Ctx(Fn.getContext()),
 			I8Ty(Type::getInt8Ty(Ctx)),
 			I16Ty(Type::getInt16Ty(Ctx)),
 			I32Ty(Type::getInt32Ty(Ctx)),
 			I64Ty(Type::getInt64Ty(Ctx)),
 			PtrTy(PointerType::getUnqual(Ctx)),
 			DoubleTy(Type::getDoubleTy(Ctx)),
-			VCtx(VCtx),
-			ObfRegIdx(VCtx.Cfg.obfRegIdx),
-			EncBytecode(VCtx.Cfg.encBytecode),
-			StrongBC(VCtx.Cfg.strongBytecode),
-			BlindTargets(VCtx.Cfg.blindTargets),
-			UseAES(VCtx.Cfg.useAES),
-			LazyDecrypt(VCtx.Cfg.lazyDecrypt),
-			RegEncrypt(VCtx.Cfg.regEncrypt),
-			RollingRegKey(VCtx.Cfg.rollingRegKey),
-			ConstInStream(VCtx.Cfg.constInStream),
-			SaltConst(VCtx.R.u32()),
+			Cfg(CfgIn), R(RIn),
+			ObfRegIdx(Cfg.obfRegIdx),
+			EncBytecode(Cfg.encBytecode),
+			StrongBC(Cfg.strongBytecode),
+			BlindTargets(Cfg.blindTargets),
+			UseAES(Cfg.useAES),
+			LazyDecrypt(Cfg.lazyDecrypt),
+			RegEncrypt(Cfg.regEncrypt),
+			RollingRegKey(Cfg.rollingRegKey),
+			ConstInStream(Cfg.constInStream),
+			NestedVM(Cfg.nestedVM),
+			NestedVMOpcodes(Cfg.nestedVMOpcodes),
+			NestedVMHardened(Cfg.nestedVMHardened),
+			EngineId(NestedVM ? 1u : 0u),
+			SaltConst(R.u32()),
 			// IMPORTANT: indices are only XOR-salted when obfRegIdx=1.
 			// When obfRegIdx=0, emitter must write raw indices (CTSalt=0).
 			CTSalt(ObfRegIdx ? (uint8_t)(SaltConst & 0xFF) : 0),
-			EncSeed(((uint64_t)VCtx.R.u32() << 32) | VCtx.R.u32()) {
+			EncSeed(((uint64_t)R.u32() << 32) | R.u32()) {
 			// per-function opcode permutation for handler-table/bytecode diversity.
-			OpMap.initPermuted(VCtx.R);
+			OpMap.initPermuted(R);
 
 			//  generate per-function AES key material from RNG
 			if (UseAES) {
 				for (int i = 0; i < 4; i++) {
-					uint32_t W = VCtx.R.u32();
+					uint32_t W = R.u32();
 					AESKey[i * 4 + 0] = (W >> 0) & 0xFF;
 					AESKey[i * 4 + 1] = (W >> 8) & 0xFF;
 					AESKey[i * 4 + 2] = (W >> 16) & 0xFF;
 					AESKey[i * 4 + 3] = (W >> 24) & 0xFF;
 				}
 				vm_aes::keyExpand(AESKey, AESExpandedKey);
-				for (auto& b : AESRKMask) b = (uint8_t)(VCtx.R.u32() & 0xFF);
-				AESNonce = ((uint64_t)VCtx.R.u32() << 32) | VCtx.R.u32();
+				for (auto& b : AESRKMask) b = (uint8_t)(R.u32() & 0xFF);
+				AESNonce = ((uint64_t)R.u32() << 32) | R.u32();
 			}
 		}
 
@@ -701,6 +753,23 @@ namespace llvm {
 		void buildHandlersFloat();     // all float/freg opcodes (LOADI_F .. FNEG)
 		void buildHandlersCall();      // CALL_VOID CALL_INT CALL_PTR CALL_INT64 CALL_F
 		void buildCall2(VMOp Opc, const Twine& Name, llvm::VMEngine::RetKind2 RK);
+
+		// Nested-VM: pure per-opcode helpers authored fresh + virtualized via a
+		// second VMImpl over the shared engine. See VMPass_Impl.cpp for the
+		// sequencing rationale.
+		Function* getOrCreateNestedBinopHelper();   // idempotent per module
+		Function* getOrCreateNestedBinop64Helper(); // idempotent per module
+		Function* getOrCreateNestedIcmpHelper();    // idempotent per module
+		Function* getOrCreateNestedIcmp64Helper();  // idempotent per module
+		Function* getOrCreateNestedFcmpHelper();    // idempotent per module
+		Function* getOrCreateNestedCastHelper();    // idempotent per module
+		Function* getOrCreateNestedHelper(VMOp Op); // dispatches to the per-opcode authors above
+		void virtualizeNestedHelpersOnce();         // idempotent per module
+
+		// Whether Op is nested for this build: NestedVM is on, and (Op is
+		// within the first NestedVMOpcodes entries of the fixed nesting order,
+		// or NestedVMOpcodes==0, meaning "all eligible opcodes nest").
+		bool opcodeNests(VMOp Op) const;
 
 		void buildHandlerTable();   // must come AFTER buildOpcodeHandlers
 		void buildDispatch();       // must come AFTER buildHandlerTable

--- a/include/llvm/Transforms/Obfuscator/VMPass_Impl.h
+++ b/include/llvm/Transforms/Obfuscator/VMPass_Impl.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/IR/BasicBlock.h"
@@ -144,24 +145,45 @@ namespace llvm {
 		static constexpr unsigned kParamFRegKeys = 16;
 		static constexpr unsigned kParamCalleeMask = 17;
 		static constexpr unsigned kNumParams = 18;
+		// Present only when the engine was built with lazyDecrypt=1 (one extra
+		// trailing ptr param). kNumParams above is unchanged so the non-lazy
+		// signature — and therefore all output when the feature is off — is
+		// byte-identical to before this param was added.
+		static constexpr unsigned kParamLazyCtx = kNumParams;
+
+		// Layout of the per-call lazy-decrypt context block (a flat byte buffer
+		// allocated by buildWrapper() and threaded through as kParamLazyCtx):
+		//   [0..175]   rk      — unmasked 176-byte AES round-key schedule
+		//   [176..183] nonce   — 8-byte AES-CTR nonce
+		//   [184..199] window  — last-fetched 16-byte AES keystream block
+		//   [200..203] cachedBlk (i32) — block index currently held in `window`
+		static constexpr unsigned kLazyCtxRKOff = 0;
+		static constexpr unsigned kLazyCtxNonceOff = 176;
+		static constexpr unsigned kLazyCtxWindowOff = 184;
+		static constexpr unsigned kLazyCtxCachedBlkOff = 200;
+		static constexpr unsigned kLazyCtxSize = 204;
 
 		/// The well-known symbol name for the shared engine function.
 		static constexpr const char* kVMEngineName = "__vm_engine";
 
-		/// Return the canonical FunctionType for vm_engine.
-		inline FunctionType* getVMEngineFunctionType(LLVMContext& Ctx) {
+		/// Return the canonical FunctionType for vm_engine. `lazy` appends the
+		/// trailing lazyctx ptr param; false (default) reproduces the exact
+		/// pre-existing signature.
+		inline FunctionType* getVMEngineFunctionType(LLVMContext& Ctx, bool lazy = false) {
 			Type* PtrTy = PointerType::getUnqual(Ctx);
 			Type* I32Ty = Type::getInt32Ty(Ctx);
 			Type* VoidTy = Type::getVoidTy(Ctx);
 			Type* I64Ty = Type::getInt64Ty(Ctx);
-			Type* Params[kNumParams] = {
+			Type* Params[kNumParams + 1] = {
 				PtrTy, I32Ty, PtrTy, PtrTy, PtrTy, PtrTy,
 				PtrTy, I32Ty, I32Ty, I32Ty, I32Ty, I32Ty,
 				PtrTy, PtrTy,
 				PtrTy, PtrTy, PtrTy,   // regkeys, reg64keys, fregkeys
 				I64Ty,                 // callee_mask
+				PtrTy,                 // lazyctx (only present when lazy)
 			};
-			return FunctionType::get(VoidTy, Params, /*isVarArg=*/false);
+			unsigned N = lazy ? (kNumParams + 1) : kNumParams;
+			return FunctionType::get(VoidTy, ArrayRef<Type*>(Params, N), /*isVarArg=*/false);
 		}
 
 		/// Get or create the module-level @__vm_engine function.
@@ -183,6 +205,7 @@ namespace llvm {
 			BasicBlock* OpcBB[OP_COUNT][kMaxHandlerVariants] = {};
 			unsigned    NumVariants = 1;   // active variant count for this engine
 			bool        EncDispatch = false;   // engine-wide: dispatch uses encrypted index map
+			bool        LazyMode = false;      // engine-wide: fetch removes AES per-block instead of ctor whole-buffer
 			BasicBlock* Dispatch = nullptr;
 			BasicBlock* ExitBB = nullptr;
 			BasicBlock* Entry = nullptr;
@@ -225,6 +248,7 @@ namespace llvm {
 		const bool     StrongBC;     // P3: per-position PRF Layer-1 keystream
 		const bool     BlindTargets; // P3-B: XOR-blind bytecode branch targets
 		const bool     UseAES;       // AES-CTR replaces LCG
+		const bool     LazyDecrypt;  // AES layer removed per-instruction at fetch instead of whole-buffer in ctor
 		const bool     RegEncrypt;   // XOR-encrypt register values at rest
 		const bool     RollingRegKey; // P4-C: evolve per-slot reg XOR key on each store
 		const uint32_t SaltConst;    // full 32-bit salt stored in vm.salt
@@ -288,6 +312,12 @@ namespace llvm {
 		// Globals for AES runtime decryption
 		GlobalVariable* GVAESExpandedKey = nullptr;  // @fn.vm.aes.rk (masked)
 		GlobalVariable* GVAESNonce = nullptr;  // @fn.vm.aes.nonce
+		GlobalVariable* GVAESRKMask = nullptr;  // @fn.vm.aes.rkmask (unmask key for GVAESExpandedKey)
+
+		// lazyDecrypt: forward-declared/looked-up once per module (during the
+		// founding function's populateVMEngine call) so the shared engine's
+		// fetch path can call it before buildEncryptCtorAES() links the stub.
+		Function* KeystreamFn = nullptr;
 
 		// Handler indirection layer
 		Function* HFn = nullptr;       // target for BasicBlock creation
@@ -302,6 +332,7 @@ namespace llvm {
 		Value* EffFTyIndices = nullptr;// FTy index table base
 		Value* EffHandlers = nullptr;  // handler table base
 		Value* EffCalleeMask = nullptr;// callee XOR mask (i64, null when off)
+		Value* EffLazyCtx = nullptr;   // lazy-decrypt context block ptr (null unless LazyDecrypt)
 		Value* MaskVR = nullptr;       // i32 mask values
 		Value* MaskVR64 = nullptr;
 		Value* MaskFR = nullptr;
@@ -349,6 +380,7 @@ namespace llvm {
 			StrongBC(VCtx.Cfg.strongBytecode),
 			BlindTargets(VCtx.Cfg.blindTargets),
 			UseAES(VCtx.Cfg.useAES),
+			LazyDecrypt(VCtx.Cfg.lazyDecrypt),
 			RegEncrypt(VCtx.Cfg.regEncrypt),
 			RollingRegKey(VCtx.Cfg.rollingRegKey),
 			SaltConst(VCtx.R.u32()),
@@ -416,12 +448,37 @@ namespace llvm {
 			return k;
 		}
 
+		// Lazy AES fetch: remove the AES-CTR layer for the byte at Idx32.
+		// Recomputes the 16-byte keystream block covering Idx32 via KeystreamFn
+		// into the per-call scratch window (EffLazyCtx), then reads the covering
+		// byte. Emitted straight-line (no control flow) so callers that assume
+		// linear emission across loadBC/loadBCDyn stay valid.
+		// Only called when LazyDecrypt (implies EncBytecode + UseAES).
+		Value* lazyAESByte(IRBuilder<>& B, Value* Idx32, const Twine& N) {
+			Value* RKPtr = B.CreateGEP(I8Ty, EffLazyCtx,
+				B.getInt64(VMEngine::kLazyCtxRKOff), N + ".lz.rk");
+			Value* NoncePtr = B.CreateGEP(I8Ty, EffLazyCtx,
+				B.getInt64(VMEngine::kLazyCtxNonceOff), N + ".lz.nc");
+			Value* WindowPtr = B.CreateGEP(I8Ty, EffLazyCtx,
+				B.getInt64(VMEngine::kLazyCtxWindowOff), N + ".lz.win");
+
+			Value* Blk = B.CreateLShr(Idx32, B.getInt32(4), N + ".lz.blk");
+			B.CreateCall(KeystreamFn, { RKPtr, NoncePtr, Blk, WindowPtr });
+			Value* ByteOff = B.CreateAnd(Idx32, B.getInt32(0xF), N + ".lz.boff");
+			Value* BytePtr = B.CreateGEP(I8Ty, WindowPtr,
+				B.CreateZExt(ByteOff, I64Ty, N + ".lz.boff64"), N + ".lz.bytep");
+			return B.CreateLoad(I8Ty, BytePtr, N + ".lz.byte");
+		}
+
 		Value* loadBC(IRBuilder<>& B, Value* IP, uint32_t Off, const Twine& N = "vm.bc") {
 			Value* Idx32 = Off ? B.CreateAdd(IP, B.getInt32(Off), N + ".i32") : IP;
 			Value* Idx64 = B.CreateSExt(Idx32, I64Ty, N + ".ip64");
 			Value* Ptr = B.CreateGEP(I8Ty, EffBC, Idx64, N + ".p");
 			Value* Raw = B.CreateLoad(I8Ty, Ptr, N);
 			if (!EncBytecode) return Raw;
+
+			if (LazyDecrypt && EffLazyCtx)
+				Raw = B.CreateXor(Raw, lazyAESByte(B, Idx32, N), N + ".aesx");
 
 			auto* SL = B.CreateLoad(I32Ty, EffSalt, N + ".s");
 			SL->setVolatile(true);
@@ -441,6 +498,9 @@ namespace llvm {
 			Value* Ptr = B.CreateGEP(I8Ty, EffBC, Idx64, N + ".p");
 			Value* Raw = B.CreateLoad(I8Ty, Ptr, N);
 			if (!EncBytecode) return Raw;
+
+			if (LazyDecrypt && EffLazyCtx)
+				Raw = B.CreateXor(Raw, lazyAESByte(B, Idx32, N), N + ".aesx");
 
 			auto* SL = B.CreateLoad(I32Ty, EffSalt, N + ".s");
 			SL->setVolatile(true);

--- a/include/llvm/Transforms/Obfuscator/VMPass_Impl.h
+++ b/include/llvm/Transforms/Obfuscator/VMPass_Impl.h
@@ -288,6 +288,7 @@ namespace llvm {
 		const unsigned NestedVMOpcodes;  // 0 = all eligible opcodes nest; N>0 = first N in the fixed order (see opcodeNests)
 		const bool     NestedVMHardened; // reserved: harden the inner VM layer
 		const bool     ThreadedDispatch; // inline fetch/decode/indirectbr into every handler's back-edge; no central vm.dispatch/vm.fetch
+		const bool     KeyedDispatch;    // XOR each opcode byte with a per-IP compile-time key at emit/fetch time
 		// Which shared engine this build targets: 0 = plain ("__vm_engine"),
 		// 1 = nesting ("__vm_engine.nest"). Derived from NestedVM, not an
 		// independent knob -- a nestedVM=true build always wants the engine
@@ -438,6 +439,7 @@ namespace llvm {
 			NestedVMOpcodes(Cfg.nestedVMOpcodes),
 			NestedVMHardened(Cfg.nestedVMHardened),
 			ThreadedDispatch(Cfg.threadedDispatch),
+			KeyedDispatch(Cfg.keyedDispatch),
 			EngineId(NestedVM ? 1u : 0u),
 			SaltConst(R.u32()),
 			// IMPORTANT: indices are only XOR-salted when obfRegIdx=1.
@@ -502,6 +504,20 @@ namespace llvm {
 			k = B.CreateMul(k, B.getInt32(0x9E3779B1u), N + ".tk1");
 			k = B.CreateXor(k, B.CreateLShr(k, B.getInt32(16), N + ".tk2s"), N + ".tk2");
 			return k;
+		}
+
+		// keyedDispatch: runtime (IR) mix — mirrors BytecodeEmitter::opKeyByteCT
+		// op-for-op. Computes the per-IP opcode-byte XOR key from the runtime
+		// salt (caller loads it, volatile, before calling this) and the
+		// fetch-time IP. Applied to the raw fetched opcode byte before the
+		// OP_COUNT urem in emitThreadedTail/buildDispatch.
+		Value* opKeyByteIR(IRBuilder<>& B, Value* Salt, Value* Idx32, const Twine& N) {
+			Value* IPp1 = B.CreateAdd(Idx32, B.getInt32(1), N + ".ok0");
+			Value* Mul = B.CreateMul(Salt, IPp1, N + ".ok1");
+			Value* Shr = B.CreateLShr(Salt, B.getInt32(8), N + ".ok2");
+			Value* K = B.CreateXor(Mul, Shr, N + ".ok3");
+			Value* Key32 = B.CreateAnd(K, B.getInt32(0xFF), N + ".okm");
+			return B.CreateTrunc(Key32, I8Ty, N + ".ok8");
 		}
 
 		// Lazy AES fetch: remove the AES-CTR layer for the byte at Idx32.

--- a/include/llvm/Transforms/Obfuscator/VMPass_Verifier.h
+++ b/include/llvm/Transforms/Obfuscator/VMPass_Verifier.h
@@ -39,6 +39,7 @@ namespace llvm {
 		std::string& OutErr,
 		uint32_t& OutBadIP,
 		uint32_t              SaltFull = 0,       // P3-B: full 32-bit salt for target un-blind
-		bool                  BlindTargets = false); // P3-B: branch targets are XOR-blinded
+		bool                  BlindTargets = false, // P3-B: branch targets are XOR-blinded
+		bool                  KeyedDispatch = false); // keyedDispatch: opcode bytes are per-IP XOR-keyed
 
 } // namespace llvm

--- a/utils/cases/_common.py
+++ b/utils/cases/_common.py
@@ -135,6 +135,12 @@ EXTRA_ANN: Dict[str, str] = {
     "vm_v7_constinstream":          "vm(minBlocks=1,obfRegIdx=1,encBytecode=1,constInStream=1)",
     "vm_v7_constinstream_lazy":     "vm(minBlocks=1,obfRegIdx=1,encBytecode=1,useAES=1,constInStream=1,lazyDecrypt=1)",
     "vm_v7_constinstream_hardened": "vm(minBlocks=1,obfRegIdx=1,encBytecode=1,constInStream=1,hardened=1)",
+    # nestedVM: BINOP/BINOP64/ICMP/ICMP64/FCMP/CAST handlers call a pure
+    # helper that is itself virtualized against a second shared engine
+    # (@__vm_engine.nest), depth-2 interpretation for those opcodes.
+    "vm_v7_nestedvm":          "vm(minBlocks=1,obfRegIdx=1,encBytecode=1,nestedVM=1)",
+    "vm_v7_nestedvm_multi_fn": "vm(minBlocks=1,obfRegIdx=1,encBytecode=1,nestedVM=1)",
+    "vm_v7_nestedvm_hardened": "vm(minBlocks=1,obfRegIdx=1,encBytecode=1,nestedVM=1,hardened=1)",
 }
 
 

--- a/utils/cases/_common.py
+++ b/utils/cases/_common.py
@@ -141,6 +141,18 @@ EXTRA_ANN: Dict[str, str] = {
     "vm_v7_nestedvm":          "vm(minBlocks=1,obfRegIdx=1,encBytecode=1,nestedVM=1)",
     "vm_v7_nestedvm_multi_fn": "vm(minBlocks=1,obfRegIdx=1,encBytecode=1,nestedVM=1)",
     "vm_v7_nestedvm_hardened": "vm(minBlocks=1,obfRegIdx=1,encBytecode=1,nestedVM=1,hardened=1)",
+    # threadedDispatch: inline the fetch/decode/indirectbr sequence into
+    # every handler's own back-edge instead of routing through one shared
+    # vm.dispatch/vm.fetch pair -- kills the single central-loop signature
+    # (one urem/GEP/indirectbr) a lifter would otherwise fingerprint.
+    "vm_v7_threaded":          "vm(minBlocks=1,obfRegIdx=1,encBytecode=1,threadedDispatch=1)",
+    "vm_v7_threaded_multi_fn": "vm(minBlocks=1,obfRegIdx=1,encBytecode=1,threadedDispatch=1)",
+    "vm_v7_threaded_hardened": "vm(minBlocks=1,obfRegIdx=1,encBytecode=1,threadedDispatch=1,hardened=1)",
+    # Full composition proof: threadedDispatch + lazyDecrypt + constInStream +
+    # nestedVM all together (nestedVM's inner engine inherits threadedDispatch
+    # from the outer Cfg via virtualizeNestedHelpersOnce()'s InnerCfg copy).
+    "vm_v7_threaded_stack":    "vm(minBlocks=1,obfRegIdx=1,encBytecode=1,useAES=1,"
+                               "threadedDispatch=1,lazyDecrypt=1,constInStream=1,nestedVM=1)",
 }
 
 

--- a/utils/cases/_common.py
+++ b/utils/cases/_common.py
@@ -153,6 +153,18 @@ EXTRA_ANN: Dict[str, str] = {
     # from the outer Cfg via virtualizeNestedHelpersOnce()'s InnerCfg copy).
     "vm_v7_threaded_stack":    "vm(minBlocks=1,obfRegIdx=1,encBytecode=1,useAES=1,"
                                "threadedDispatch=1,lazyDecrypt=1,constInStream=1,nestedVM=1)",
+    # keyedDispatch: each opcode byte is XOR'd with a per-IP compile-time key
+    # at emit time (BytecodeEmitter::bop) and un-XOR'd at fetch time
+    # (emitThreadedTail/buildDispatch); same physical byte decodes to a
+    # different logical opcode depending on where it's read from.
+    "vm_v7_keyeddisp":          "vm(minBlocks=1,obfRegIdx=1,encBytecode=1,keyedDispatch=1)",
+    "vm_v7_keyeddisp_multi_fn": "vm(minBlocks=1,obfRegIdx=1,encBytecode=1,keyedDispatch=1)",
+    "vm_v7_keyeddisp_hardened": "vm(minBlocks=1,obfRegIdx=1,encBytecode=1,keyedDispatch=1,hardened=1)",
+    # Full composition proof: keyedDispatch + threadedDispatch + encDispatch +
+    # lazyDecrypt + constInStream + nestedVM all together.
+    "vm_v7_keyeddisp_stack":    "vm(minBlocks=1,obfRegIdx=1,encBytecode=1,useAES=1,"
+                               "keyedDispatch=1,threadedDispatch=1,encDispatch=1,"
+                               "lazyDecrypt=1,constInStream=1,nestedVM=1)",
 }
 
 

--- a/utils/cases/_common.py
+++ b/utils/cases/_common.py
@@ -129,6 +129,12 @@ EXTRA_ANN: Dict[str, str] = {
     "vm_v7_lazydecrypt":          "vm(minBlocks=1,obfRegIdx=1,encBytecode=1,useAES=1,lazyDecrypt=1)",
     "vm_v7_lazydecrypt_hardened": "vm(minBlocks=1,obfRegIdx=1,encBytecode=1,useAES=1,lazyDecrypt=1,hardened=1,encDispatch=1,handlerVariants=3)",
     "vm_v7_lazydecrypt_multi_fn": "vm(minBlocks=1,obfRegIdx=1,encBytecode=1,useAES=1,lazyDecrypt=1)",
+    # constInStream: int/i64/fp constants move from plaintext wrapper preload
+    # stores into the encrypted bytecode stream as an OP_LOADI*/OP_LOADI_F
+    # prologue. Requires encBytecode (default on here).
+    "vm_v7_constinstream":          "vm(minBlocks=1,obfRegIdx=1,encBytecode=1,constInStream=1)",
+    "vm_v7_constinstream_lazy":     "vm(minBlocks=1,obfRegIdx=1,encBytecode=1,useAES=1,constInStream=1,lazyDecrypt=1)",
+    "vm_v7_constinstream_hardened": "vm(minBlocks=1,obfRegIdx=1,encBytecode=1,constInStream=1,hardened=1)",
 }
 
 

--- a/utils/cases/_common.py
+++ b/utils/cases/_common.py
@@ -123,6 +123,12 @@ EXTRA_ANN: Dict[str, str] = {
     "vm_v7_rolling":        "vm(minBlocks=1,obfRegIdx=1,encBytecode=1,regEncrypt=1,rollingRegKey=1)",
     # Full P2+P3 stack: variants + keyed dispatch + strong keystream + target blinding + hardened.
     "vm_v7_p3_full":        "vm(minBlocks=1,obfRegIdx=1,encBytecode=1,strongBytecode=1,blindTargets=1,encDispatch=1,hardened=1,handlerVariants=3)",
+    # lazyDecrypt (P5): AES layer removed per-instruction at fetch (block-cached
+    # in a per-call context) instead of by the ctor decrypting the whole
+    # runtime buffer up front. Requires useAES + encBytecode.
+    "vm_v7_lazydecrypt":          "vm(minBlocks=1,obfRegIdx=1,encBytecode=1,useAES=1,lazyDecrypt=1)",
+    "vm_v7_lazydecrypt_hardened": "vm(minBlocks=1,obfRegIdx=1,encBytecode=1,useAES=1,lazyDecrypt=1,hardened=1,encDispatch=1,handlerVariants=3)",
+    "vm_v7_lazydecrypt_multi_fn": "vm(minBlocks=1,obfRegIdx=1,encBytecode=1,useAES=1,lazyDecrypt=1)",
 }
 
 

--- a/utils/cases/vm.py
+++ b/utils/cases/vm.py
@@ -55,6 +55,14 @@ VM_REGENC_GATES = [
     "vm_regenc_key_geps", "vm_regenc_pregs_exempt",
 ]
 
+# lazyDecrypt: AES layer removed per-instruction at fetch instead of by the
+# ctor decrypting the whole runtime buffer up front. Feature-active gate:
+# the engine must actually call the per-block keystream helper, and the
+# ctor must NOT still call the whole-buffer decrypt.
+VM_LAZYDECRYPT_GATES = [
+    "vm_lazydecrypt_keystream_call", "vm_lazydecrypt_ctor_no_bulk_decrypt",
+]
+
 _DBG = ["--obf-debug", "--obf-verbose"]
 
 
@@ -394,3 +402,42 @@ def register(reg: Registry, **_opts) -> None:
     reg.add(name="rt_vm_v7_regenc_seed_divergence", passes=["vm"],
             ann_override=vm_v7_regenc,
             gates=["seed_divergence"], category="vm")
+
+    # ── P5-A lazy decrypt (lazyDecrypt=1) ──
+    # AES layer removed per bytecode-fetch instead of by the ctor decrypting
+    # the whole runtime buffer up front. Correctness gate: differential
+    # output proves the per-block keystream + windowed cache round-trips the
+    # same bytecode the eager path decrypts in one shot. Feature-active gate
+    # (VM_LAZYDECRYPT_GATES) proves the lazy path was actually taken, not
+    # silently ignored/back off to eager.
+    vm_v7_lazy = ann_extra("vm_v7_lazydecrypt")
+    vm_v7_lazy_multi = ann_extra("vm_v7_lazydecrypt_multi_fn")
+
+    reg.add(name="rt_vm_v7_lazydecrypt_multi_fn", passes=["vm"],
+            ann_override=vm_v7_lazy_multi,
+            gates=VM_SHARED_GATES + VM_AES_GATES + VM_LAZYDECRYPT_GATES + [
+                "vm_enc_ctor", "vm_callees_global", "vm_multi_fn_shared",
+            ],
+            extra_opts=_DBG, category="vm",
+            src_override=render_vm_v7_multi_fn_aes_program(vm_v7_lazy_multi))
+    reg.add(name="rt_vm_v7_lazydecrypt_i64", passes=["vm"],
+            ann_override=vm_v7_lazy,
+            gates=VM_CORE_GATES + VM_AES_GATES + VM_LAZYDECRYPT_GATES + ["vm_enc_ctor"],
+            extra_opts=_DBG, category="vm",
+            src_override=render_vm_v7_i64_ops_program(vm_v7_lazy))
+    reg.add(name="rt_vm_v7_lazydecrypt_float", passes=["vm"],
+            ann_override=vm_v7_lazy,
+            gates=VM_FLOAT_GATES + VM_AES_GATES + VM_LAZYDECRYPT_GATES,
+            extra_opts=_DBG, category="vm",
+            src_override=render_vm_v7_float_basic_program(vm_v7_lazy))
+    reg.add(name="rt_vm_v7_lazydecrypt_switch", passes=["vm"],
+            ann_override=vm_v7_lazy,
+            gates=VM_SHARED_GATES + VM_AES_GATES + VM_LAZYDECRYPT_GATES + [
+                "vm_enc_ctor", "vm_multi_fn_shared",
+            ],
+            extra_opts=_DBG, category="vm",
+            src_override=render_vm_v7_switch_dispatch_program(vm_v7_lazy))
+    reg.add(name="rt_vm_v7_lazydecrypt_determinism", passes=["vm"],
+            ann_override=vm_v7_lazy,
+            extra_opts=_DBG, gates=["seed_determinism"], category="vm",
+            src_override=render_vm_v7_multi_function_program(vm_v7_lazy))

--- a/utils/cases/vm.py
+++ b/utils/cases/vm.py
@@ -70,6 +70,13 @@ VM_LAZYDECRYPT_GATES = [
 # the bytecode stream.
 VM_CONSTINSTREAM_GATES = ["vm_constinstream_no_plaintext_magic"]
 
+# nestedVM: BINOP/BINOP64/ICMP/ICMP64/FCMP/CAST handlers call a pure helper
+# that is itself virtualized against a second shared engine. Feature-active
+# gate: both @__vm_engine and @__vm_engine.nest must exist, and at least one
+# @__vm_h_* helper must have been virtualized (its own handler table targets
+# the plain @__vm_engine). Off: neither .nest nor __vm_h_* present.
+VM_NESTEDVM_GATES = ["vm_nestedvm_dual_engine", "vm_nestedvm_helper_virtualized"]
+
 _DBG = ["--obf-debug", "--obf-verbose"]
 
 
@@ -494,3 +501,44 @@ def register(reg: Registry, **_opts) -> None:
             gates=VM_CORE_GATES + VM_AES_GATES + VM_LAZYDECRYPT_GATES,
             extra_opts=_DBG, category="vm",
             src_override=render_vm_v7_i64_ops_program(vm_v7_cis_lazy))
+
+    # ── nestedVM (BINOP/BINOP64/ICMP/ICMP64/FCMP/CAST call an inner-
+    # virtualized pure helper instead of computing inline) ──
+    # Correctness gate: differential output proves the depth-2 interpretation
+    # (outer engine -> helper call -> plain engine) computes the exact same
+    # result as the inline handlers. Feature-active gate (VM_NESTEDVM_GATES)
+    # proves both engines exist and the helper was actually virtualized.
+    vm_v7_nvm = ann_extra("vm_v7_nestedvm")
+    vm_v7_nvm_multi = ann_extra("vm_v7_nestedvm_multi_fn")
+
+    reg.add(name="rt_vm_v7_nestedvm_multi_fn", passes=["vm"],
+            ann_override=vm_v7_nvm_multi,
+            gates=VM_SHARED_GATES + VM_NESTEDVM_GATES + [
+                "vm_enc_ctor", "vm_callees_global", "vm_multi_fn_shared",
+            ],
+            extra_opts=_DBG, category="vm",
+            src_override=render_vm_v7_multi_fn_aes_program(vm_v7_nvm_multi))
+    reg.add(name="rt_vm_v7_nestedvm_i64", passes=["vm"],
+            ann_override=vm_v7_nvm,
+            gates=VM_CORE_GATES + VM_NESTEDVM_GATES + ["vm_enc_ctor"],
+            extra_opts=_DBG, category="vm",
+            src_override=render_vm_v7_i64_ops_program(vm_v7_nvm))
+    reg.add(name="rt_vm_v7_nestedvm_float", passes=["vm"],
+            ann_override=vm_v7_nvm,
+            gates=VM_FLOAT_GATES + VM_NESTEDVM_GATES,
+            extra_opts=_DBG, category="vm",
+            src_override=render_vm_v7_float_fcmp_program(vm_v7_nvm))
+    reg.add(name="rt_vm_v7_nestedvm_cast", passes=["vm"],
+            ann_override=vm_v7_nvm,
+            gates=VM_CORE_GATES + VM_NESTEDVM_GATES + ["vm_enc_ctor"],
+            extra_opts=_DBG, category="vm",
+            src_override=render_vm_v7_casts_program(vm_v7_nvm))
+    reg.add(name="rt_vm_v7_nestedvm_cmp", passes=["vm"],
+            ann_override=vm_v7_nvm,
+            gates=VM_CORE_GATES + VM_NESTEDVM_GATES + ["vm_enc_ctor"],
+            extra_opts=_DBG, category="vm",
+            src_override=render_vm_v7_icmp_program(vm_v7_nvm))
+    reg.add(name="rt_vm_v7_nestedvm_determinism", passes=["vm"],
+            ann_override=vm_v7_nvm,
+            extra_opts=_DBG, gates=["seed_determinism"], category="vm",
+            src_override=render_vm_v7_multi_function_program(vm_v7_nvm))

--- a/utils/cases/vm.py
+++ b/utils/cases/vm.py
@@ -77,6 +77,16 @@ VM_CONSTINSTREAM_GATES = ["vm_constinstream_no_plaintext_magic"]
 # the plain @__vm_engine). Off: neither .nest nor __vm_h_* present.
 VM_NESTEDVM_GATES = ["vm_nestedvm_dual_engine", "vm_nestedvm_helper_virtualized"]
 
+# threadedDispatch: no single central vm.dispatch/vm.fetch pair, so the
+# structural gates that assert one (vm_dispatch_present, vm_engine_dispatch)
+# don't apply -- everything else in VM_CORE_GATES/VM_ENGINE_GATES still holds
+# (each handler still ends in its own indirectbr, opcode blocks are named the
+# same way, the wrapper is still thin, etc).
+VM_THREADED_CORE_GATES = [g for g in VM_CORE_GATES if g != "vm_dispatch_present"]
+VM_THREADED_ENGINE_GATES = [g for g in VM_ENGINE_GATES if g != "vm_engine_dispatch"]
+VM_THREADED_SHARED_GATES = VM_THREADED_CORE_GATES + VM_THREADED_ENGINE_GATES
+VM_THREADED_GATES = ["vm_threaded_no_central_dispatch"]
+
 _DBG = ["--obf-debug", "--obf-verbose"]
 
 
@@ -85,7 +95,7 @@ def register(reg: Registry, **_opts) -> None:
 
     reg.add(name="rt_vm_v7_basic", passes=["vm"],
             ann_override=vm_v7,
-            gates=VM_CORE_GATES + ["vm_enc_ctor"],
+            gates=VM_CORE_GATES + ["vm_enc_ctor", "vm_no_threaded_dispatch"],
             extra_opts=_DBG, category="vm")
     reg.add(name="rt_vm_v7_bare", passes=["vm"],
             ann_override=ann_extra("vm_v7_bare"),
@@ -542,3 +552,71 @@ def register(reg: Registry, **_opts) -> None:
             ann_override=vm_v7_nvm,
             extra_opts=_DBG, gates=["seed_determinism"], category="vm",
             src_override=render_vm_v7_multi_function_program(vm_v7_nvm))
+
+    # ── threadedDispatch (every handler inlines its own fetch/decode/
+    # indirectbr tail instead of routing through one shared vm.dispatch/
+    # vm.fetch pair) ──
+    # Correctness gate: differential output proves the per-handler inlined
+    # tail fetches/decodes/dispatches the exact same bytecode stream as the
+    # central-dispatch build. Feature-active gate (VM_THREADED_GATES) proves
+    # the central dispatch loop signature is actually gone, not silently
+    # falling back to it.
+    vm_v7_thr = ann_extra("vm_v7_threaded")
+    vm_v7_thr_multi = ann_extra("vm_v7_threaded_multi_fn")
+    vm_v7_thr_hard = ann_extra("vm_v7_threaded_hardened")
+    vm_v7_thr_stack = ann_extra("vm_v7_threaded_stack")
+
+    reg.add(name="rt_vm_v7_threaded_multi_fn", passes=["vm"],
+            ann_override=vm_v7_thr_multi,
+            gates=VM_THREADED_SHARED_GATES + VM_THREADED_GATES + [
+                "vm_enc_ctor", "vm_callees_global", "vm_multi_fn_shared",
+            ],
+            extra_opts=_DBG, category="vm",
+            src_override=render_vm_v7_multi_fn_aes_program(vm_v7_thr_multi))
+    reg.add(name="rt_vm_v7_threaded_i64", passes=["vm"],
+            ann_override=vm_v7_thr,
+            gates=VM_THREADED_CORE_GATES + VM_THREADED_GATES + ["vm_enc_ctor"],
+            extra_opts=_DBG, category="vm",
+            src_override=render_vm_v7_i64_ops_program(vm_v7_thr))
+    reg.add(name="rt_vm_v7_threaded_float", passes=["vm"],
+            ann_override=vm_v7_thr,
+            gates=VM_THREADED_CORE_GATES + VM_THREADED_GATES + [
+                "vm_fregs_alloca", "vm_enc_ctor",
+            ],
+            extra_opts=_DBG, category="vm",
+            src_override=render_vm_v7_float_basic_program(vm_v7_thr))
+    reg.add(name="rt_vm_v7_threaded_switch", passes=["vm"],
+            ann_override=vm_v7_thr,
+            gates=VM_THREADED_SHARED_GATES + VM_THREADED_GATES + [
+                "vm_enc_ctor", "vm_multi_fn_shared",
+            ],
+            extra_opts=_DBG, category="vm",
+            src_override=render_vm_v7_switch_dispatch_program(vm_v7_thr))
+    # hardened + threadedDispatch: the dead-block/pre-dispatch-split hardening
+    # (vm_hardened_dead_blocks/vm_hardened_dispatch_guard) is a structural
+    # no-op under threadedDispatch (no SS->Dispatch to split -- see
+    # hardenVMEngine's `if (!ThreadedDispatch && SS->Dispatch)` gate), so
+    # those two gates are intentionally excluded here. MBA and handler-entry
+    # guards stay active and are still checked.
+    reg.add(name="rt_vm_v7_threaded_hardened", passes=["vm"],
+            ann_override=vm_v7_thr_hard,
+            gates=VM_THREADED_CORE_GATES + VM_THREADED_GATES + [
+                "vm_enc_ctor", "vm_hardened_mba", "vm_hardened_handler_guards",
+            ],
+            extra_opts=_DBG, category="vm")
+    # Full-stack composition: threadedDispatch + lazyDecrypt + constInStream +
+    # nestedVM together. Proves nextInsn()/emitThreadedTail() composes with
+    # the lazy-AES fetch path, the encrypted-stream constant prologue, and
+    # the inner nested-VM engine (whose own InnerCfg copies threadedDispatch
+    # from the outer Cfg, so both engines dispatch the same way).
+    reg.add(name="rt_vm_v7_threaded_stack", passes=["vm"],
+            ann_override=vm_v7_thr_stack,
+            gates=VM_THREADED_SHARED_GATES + VM_THREADED_GATES
+                + VM_AES_GATES + VM_LAZYDECRYPT_GATES + VM_CONSTINSTREAM_GATES
+                + VM_NESTEDVM_GATES + ["vm_enc_ctor", "vm_multi_fn_shared"],
+            extra_opts=_DBG, category="vm",
+            src_override=render_vm_v7_switch_dispatch_program(vm_v7_thr_stack))
+    reg.add(name="rt_vm_v7_threaded_determinism", passes=["vm"],
+            ann_override=vm_v7_thr,
+            extra_opts=_DBG, gates=["seed_determinism"], category="vm",
+            src_override=render_vm_v7_multi_function_program(vm_v7_thr))

--- a/utils/cases/vm.py
+++ b/utils/cases/vm.py
@@ -87,6 +87,12 @@ VM_THREADED_ENGINE_GATES = [g for g in VM_ENGINE_GATES if g != "vm_engine_dispat
 VM_THREADED_SHARED_GATES = VM_THREADED_CORE_GATES + VM_THREADED_ENGINE_GATES
 VM_THREADED_GATES = ["vm_threaded_no_central_dispatch"]
 
+# keyedDispatch: each opcode byte is XOR'd with a per-IP compile-time key at
+# emit time and un-XOR'd at fetch time. Purely a byte-value transform on the
+# existing dispatch path -- doesn't change dispatch structure, so it composes
+# with any of the CORE/ENGINE/THREADED gate sets above.
+VM_KEYEDDISP_GATES = ["vm_keyeddisp_ip_xor"]
+
 _DBG = ["--obf-debug", "--obf-verbose"]
 
 
@@ -95,7 +101,7 @@ def register(reg: Registry, **_opts) -> None:
 
     reg.add(name="rt_vm_v7_basic", passes=["vm"],
             ann_override=vm_v7,
-            gates=VM_CORE_GATES + ["vm_enc_ctor", "vm_no_threaded_dispatch"],
+            gates=VM_CORE_GATES + ["vm_enc_ctor", "vm_no_threaded_dispatch", "vm_no_keyeddisp"],
             extra_opts=_DBG, category="vm")
     reg.add(name="rt_vm_v7_bare", passes=["vm"],
             ann_override=ann_extra("vm_v7_bare"),
@@ -620,3 +626,71 @@ def register(reg: Registry, **_opts) -> None:
             ann_override=vm_v7_thr,
             extra_opts=_DBG, gates=["seed_determinism"], category="vm",
             src_override=render_vm_v7_multi_function_program(vm_v7_thr))
+
+    # ── keyedDispatch (XOR every opcode byte with a per-IP compile-time key
+    # at write time in BytecodeEmitter::bop(), un-XOR at fetch time in
+    # emitThreadedTail/buildDispatch and verifyBytecode) ──
+    # Correctness gate: differential output proves the same physical bytecode
+    # decodes correctly through the per-IP un-XOR at every fetch site.
+    # Feature-active gate (VM_KEYEDDISP_GATES) proves the IR actually emits
+    # the per-IP key mix and opcode-byte XOR, not silently falling back to a
+    # plain fetch.
+    vm_v7_kd = ann_extra("vm_v7_keyeddisp")
+    vm_v7_kd_multi = ann_extra("vm_v7_keyeddisp_multi_fn")
+    vm_v7_kd_hard = ann_extra("vm_v7_keyeddisp_hardened")
+    vm_v7_kd_stack = ann_extra("vm_v7_keyeddisp_stack")
+
+    reg.add(name="rt_vm_v7_keyeddisp_multi_fn", passes=["vm"],
+            ann_override=vm_v7_kd_multi,
+            gates=VM_SHARED_GATES + VM_KEYEDDISP_GATES + [
+                "vm_enc_ctor", "vm_callees_global", "vm_multi_fn_shared",
+            ],
+            extra_opts=_DBG, category="vm",
+            src_override=render_vm_v7_multi_fn_aes_program(vm_v7_kd_multi))
+    reg.add(name="rt_vm_v7_keyeddisp_i64", passes=["vm"],
+            ann_override=vm_v7_kd,
+            gates=VM_SHARED_GATES + VM_KEYEDDISP_GATES + ["vm_enc_ctor"],
+            extra_opts=_DBG, category="vm",
+            src_override=render_vm_v7_i64_ops_program(vm_v7_kd))
+    reg.add(name="rt_vm_v7_keyeddisp_float", passes=["vm"],
+            ann_override=vm_v7_kd,
+            gates=VM_SHARED_GATES + VM_KEYEDDISP_GATES + [
+                "vm_fregs_alloca", "vm_enc_ctor",
+            ],
+            extra_opts=_DBG, category="vm",
+            src_override=render_vm_v7_float_basic_program(vm_v7_kd))
+    reg.add(name="rt_vm_v7_keyeddisp_switch", passes=["vm"],
+            ann_override=vm_v7_kd,
+            gates=VM_SHARED_GATES + VM_KEYEDDISP_GATES + [
+                "vm_enc_ctor", "vm_multi_fn_shared",
+            ],
+            extra_opts=_DBG, category="vm",
+            src_override=render_vm_v7_switch_dispatch_program(vm_v7_kd))
+    # hardened + keyedDispatch: hardening operates on handler-block bodies
+    # (MBA, dead blocks, dispatch/handler guards) which are all still present
+    # under keyedDispatch (a pure byte-value transform on the opcode fetch,
+    # not a dispatch-structure change), so the full hardened gate set applies
+    # unchanged (cf. rt_vm_v7_hardened above).
+    reg.add(name="rt_vm_v7_keyeddisp_hardened", passes=["vm"],
+            ann_override=vm_v7_kd_hard,
+            gates=VM_CORE_GATES + VM_KEYEDDISP_GATES + [
+                "vm_enc_ctor", "vm_hardened_mba", "vm_hardened_dead_blocks",
+                "vm_hardened_dispatch_guard", "vm_hardened_handler_guards",
+            ],
+            extra_opts=_DBG, category="vm")
+    # Full-stack composition: keyedDispatch + threadedDispatch + encDispatch +
+    # lazyDecrypt + constInStream + nestedVM together. Proves the per-IP
+    # opcode un-XOR composes with the inlined threaded fetch tail, the
+    # encrypted dispatch map, the lazy-AES fetch path, the encrypted-stream
+    # constant prologue, and the inner nested-VM engine.
+    reg.add(name="rt_vm_v7_keyeddisp_stack", passes=["vm"],
+            ann_override=vm_v7_kd_stack,
+            gates=VM_THREADED_SHARED_GATES + VM_THREADED_GATES + VM_KEYEDDISP_GATES
+                + VM_AES_GATES + VM_LAZYDECRYPT_GATES + VM_CONSTINSTREAM_GATES
+                + VM_NESTEDVM_GATES + ["vm_enc_ctor", "vm_multi_fn_shared"],
+            extra_opts=_DBG, category="vm",
+            src_override=render_vm_v7_switch_dispatch_program(vm_v7_kd_stack))
+    reg.add(name="rt_vm_v7_keyeddisp_determinism", passes=["vm"],
+            ann_override=vm_v7_kd,
+            extra_opts=_DBG, gates=["seed_determinism"], category="vm",
+            src_override=render_vm_v7_multi_function_program(vm_v7_kd))

--- a/utils/cases/vm.py
+++ b/utils/cases/vm.py
@@ -63,6 +63,13 @@ VM_LAZYDECRYPT_GATES = [
     "vm_lazydecrypt_keystream_call", "vm_lazydecrypt_ctor_no_bulk_decrypt",
 ]
 
+# constInStream: int/i64/fp constants are seeded from an encrypted-bytecode
+# prologue instead of plaintext wrapper stores. Feature-active gate: a known
+# magic constant used by the switch-dispatch program must not appear as a
+# plaintext `store i32 <magic>` immediate once constInStream moves it into
+# the bytecode stream.
+VM_CONSTINSTREAM_GATES = ["vm_constinstream_no_plaintext_magic"]
+
 _DBG = ["--obf-debug", "--obf-verbose"]
 
 
@@ -441,3 +448,49 @@ def register(reg: Registry, **_opts) -> None:
             ann_override=vm_v7_lazy,
             extra_opts=_DBG, gates=["seed_determinism"], category="vm",
             src_override=render_vm_v7_multi_function_program(vm_v7_lazy))
+
+    # ── constInStream (int/i64/fp constants seeded from the encrypted
+    # bytecode stream instead of plaintext wrapper preload stores) ──
+    # Correctness gate: differential output proves the OP_LOADI/OP_LOADI64/
+    # OP_LOADI_F prologue seeds the same values the plaintext stores used to.
+    # Feature-active gate (VM_CONSTINSTREAM_GATES, switch case only) proves
+    # the constant actually left the plaintext wrapper.
+    vm_v7_cis = ann_extra("vm_v7_constinstream")
+    vm_v7_cis_lazy = ann_extra("vm_v7_constinstream_lazy")
+
+    reg.add(name="rt_vm_v7_constinstream_multi_fn", passes=["vm"],
+            ann_override=vm_v7_cis,
+            gates=VM_SHARED_GATES + [
+                "vm_enc_ctor", "vm_callees_global", "vm_multi_fn_shared",
+            ],
+            extra_opts=_DBG, category="vm",
+            src_override=render_vm_v7_multi_fn_aes_program(vm_v7_cis))
+    reg.add(name="rt_vm_v7_constinstream_i64", passes=["vm"],
+            ann_override=vm_v7_cis,
+            gates=VM_CORE_GATES + ["vm_enc_ctor"],
+            extra_opts=_DBG, category="vm",
+            src_override=render_vm_v7_i64_ops_program(vm_v7_cis))
+    reg.add(name="rt_vm_v7_constinstream_float", passes=["vm"],
+            ann_override=vm_v7_cis,
+            gates=VM_FLOAT_GATES,
+            extra_opts=_DBG, category="vm",
+            src_override=render_vm_v7_float_basic_program(vm_v7_cis))
+    reg.add(name="rt_vm_v7_constinstream_switch", passes=["vm"],
+            ann_override=vm_v7_cis,
+            gates=VM_SHARED_GATES + VM_CONSTINSTREAM_GATES + [
+                "vm_enc_ctor", "vm_multi_fn_shared",
+            ],
+            extra_opts=_DBG, category="vm",
+            src_override=render_vm_v7_switch_dispatch_program(vm_v7_cis))
+    reg.add(name="rt_vm_v7_constinstream_determinism", passes=["vm"],
+            ann_override=vm_v7_cis,
+            extra_opts=_DBG, gates=["seed_determinism"], category="vm",
+            src_override=render_vm_v7_multi_function_program(vm_v7_cis))
+    # constInStream + lazyDecrypt combined: proves the encrypted-stream
+    # prologue round-trips correctly under the per-instruction fetch-time AES
+    # keystream path too, not just the whole-buffer-decrypt-in-ctor path.
+    reg.add(name="rt_vm_v7_constinstream_lazy", passes=["vm"],
+            ann_override=vm_v7_cis_lazy,
+            gates=VM_CORE_GATES + VM_AES_GATES + VM_LAZYDECRYPT_GATES,
+            extra_opts=_DBG, category="vm",
+            src_override=render_vm_v7_i64_ops_program(vm_v7_cis_lazy))

--- a/utils/gates/vm.py
+++ b/utils/gates/vm.py
@@ -191,3 +191,17 @@ def vm_lazydecrypt_ctor_no_bulk_decrypt(ir: str) -> Optional[str]:
             return ("vm ctor calls __obf_aes_ctr_decrypt — whole-buffer "
                      "decrypt was not removed under lazyDecrypt")
     return None
+
+
+@register("vm_constinstream_no_plaintext_magic")
+def vm_constinstream_no_plaintext_magic(ir: str) -> Optional[str]:
+    # programs/vm/switch_dispatch.c.tmpl's obf_classify() case 1 does
+    # `r = x ^ 0xABCDu;` (43981 decimal). Without constInStream this i32
+    # constant is seeded by a plaintext `store i32 43981, ...` in vm.entry /
+    # the shared-engine wrapper's preload section. Under constInStream it is
+    # folded into the encrypted bytecode stream as an OP_LOADI prologue
+    # instruction instead, so the plaintext store must be gone.
+    if re.search(r"store i32 43981\b", ir):
+        return ("plaintext `store i32 43981` (0xABCDu) found — constant "
+                 "was not moved into the bytecode stream")
+    return None

--- a/utils/gates/vm.py
+++ b/utils/gates/vm.py
@@ -161,3 +161,33 @@ def vm_obf_aes_ctr_present(ir: str) -> Optional[str]:
     if "__obf_aes_ctr_decrypt" not in ir:
         return "__obf_aes_ctr_decrypt not found — AES stub not linked"
     return None
+
+
+@register("vm_lazydecrypt_keystream_call")
+def vm_lazydecrypt_keystream_call(ir: str) -> Optional[str]:
+    # The whole AES stub module (incl. the __obf_aes_ctr_keystream_block
+    # *definition*) is linked in whenever useAES=1, lazy or not, so a bare
+    # substring match on the callee name would always pass. Require an
+    # actual `call` instruction instead — only the lazy fetch path emits one.
+    if not re.search(r"\bcall\b[^\n]*@__obf_aes_ctr_keystream_block\s*\(", ir):
+        return ("no call to __obf_aes_ctr_keystream_block found — "
+                "lazy per-block fetch path not emitted")
+    return None
+
+
+@register("vm_lazydecrypt_ctor_no_bulk_decrypt")
+def vm_lazydecrypt_ctor_no_bulk_decrypt(ir: str) -> Optional[str]:
+    # Scoped to the .vm.ctor function bodies specifically: the linked-in AES
+    # stub also contains __aes_decrypt (strenc's entry point), whose body
+    # itself calls __obf_aes_ctr_decrypt — that call is unrelated and would
+    # false-negative a whole-module substring/regex check.
+    ctor_bodies = re.findall(
+        r"define[^\n]*@\"?[\w.$]*\.vm\.ctor[\w.$]*\"?\s*\([^\n]*\{(.*?)\n\}",
+        ir, re.DOTALL)
+    if not ctor_bodies:
+        return "no .vm.ctor function found — AES ctor not built"
+    for body in ctor_bodies:
+        if re.search(r"\bcall\b[^\n]*@__obf_aes_ctr_decrypt\s*\(", body):
+            return ("vm ctor calls __obf_aes_ctr_decrypt — whole-buffer "
+                     "decrypt was not removed under lazyDecrypt")
+    return None

--- a/utils/gates/vm.py
+++ b/utils/gates/vm.py
@@ -205,3 +205,34 @@ def vm_constinstream_no_plaintext_magic(ir: str) -> Optional[str]:
         return ("plaintext `store i32 43981` (0xABCDu) found — constant "
                  "was not moved into the bytecode stream")
     return None
+
+
+@register("vm_nestedvm_dual_engine")
+def vm_nestedvm_dual_engine(ir: str) -> Optional[str]:
+    # nestedVM=1 targets EngineId 1 (@__vm_engine.nest) for the outer
+    # function, but every nested-eligible opcode's helper is always
+    # inner-virtualized against EngineId 0 (@__vm_engine, plain) -- that's
+    # what makes the depth-2 recursion terminate. Both engine functions must
+    # therefore be present. Off (nestedVM=0) only @__vm_engine exists.
+    if "@__vm_engine(" not in ir:
+        return "@__vm_engine (plain) not found"
+    if "@__vm_engine.nest(" not in ir:
+        return "@__vm_engine.nest not found — nesting engine was not built"
+    return None
+
+
+@register("vm_nestedvm_helper_virtualized")
+def vm_nestedvm_helper_virtualized(ir: str) -> Optional[str]:
+    # At least one __vm_h_* pure helper (see kNestedHelperOrder in
+    # VMPass_Impl.cpp) must exist, and it must itself have been virtualized
+    # -- proven by its own per-function handler table (<name>.vm.ophandlers)
+    # referencing the PLAIN engine (@__vm_engine), never the nesting engine.
+    # A helper left un-virtualized would still be a bare switch/ret function
+    # with no .vm.ophandlers table at all.
+    tables = re.findall(r"@__vm_h_\w+\.vm\.ophandlers\s*=[^\n]*", ir)
+    if not tables:
+        return "no @__vm_h_*.vm.ophandlers table found — nested helper was never virtualized"
+    for line in tables:
+        if re.search(r"@__vm_engine(?!\.nest)\b", line):
+            return None
+    return "nested helper handler table(s) do not reference the plain @__vm_engine"

--- a/utils/gates/vm.py
+++ b/utils/gates/vm.py
@@ -271,3 +271,26 @@ def vm_no_threaded_dispatch(ir: str) -> Optional[str]:
     if n != 1:
         return f"__vm_engine has {n} indirectbr(s), expected exactly 1 (central dispatch)"
     return None
+
+
+@register("vm_keyeddisp_ip_xor")
+def vm_keyeddisp_ip_xor(ir: str) -> Optional[str]:
+    # keyedDispatch: VMImpl::opKeyByteIR computes a per-IP XOR key (named
+    # ...vm.opk*) that emitThreadedTail/buildDispatch XOR into the raw fetched
+    # opcode byte (result named ...vm.opd) before it's mapped to a handler.
+    # Both name fragments only appear when keyedDispatch=1 emits the
+    # un-XOR sequence.
+    if not re.search(r"vm\.opk", ir):
+        return "no vm.opk value found — opKeyByteIR key mix not emitted"
+    if not re.search(r"vm\.opd", ir):
+        return "no vm.opd value found — opcode-byte un-XOR not emitted"
+    return None
+
+
+@register("vm_no_keyeddisp")
+def vm_no_keyeddisp(ir: str) -> Optional[str]:
+    # Inverse of vm_keyeddisp_ip_xor — proves the per-IP opcode-byte XOR is
+    # absent when keyedDispatch=0.
+    if re.search(r"vm\.opk|vm\.opd", ir):
+        return "vm.opk/vm.opd found but keyedDispatch=0"
+    return None

--- a/utils/gates/vm.py
+++ b/utils/gates/vm.py
@@ -6,6 +6,7 @@ import re
 from typing import Optional
 
 from . import register
+from ._ir import extract_fn_body
 
 
 @register("vm_dispatch_present")
@@ -236,3 +237,37 @@ def vm_nestedvm_helper_virtualized(ir: str) -> Optional[str]:
         if re.search(r"@__vm_engine(?!\.nest)\b", line):
             return None
     return "nested helper handler table(s) do not reference the plain @__vm_engine"
+
+
+@register("vm_threaded_no_central_dispatch")
+def vm_threaded_no_central_dispatch(ir: str) -> Optional[str]:
+    # threadedDispatch: every handler inlines its own fetch/decode/indirectbr
+    # tail (see emitThreadedTail() in VMPass_Impl.cpp) instead of routing
+    # through one shared vm.dispatch/vm.fetch pair. Two independent signals:
+    # no vm.fetch block anywhere, and __vm_engine ends up with far more than
+    # the single indirectbr a central-dispatch build has (one per handler).
+    if re.search(r"\bvm\.fetch\b", ir):
+        return "vm.fetch block found — central dispatch was not threaded away"
+    engine = extract_fn_body(ir, "__vm_engine")
+    if engine is None:
+        return "__vm_engine function body not found"
+    n = len(re.findall(r"\bindirectbr\b", engine))
+    if n <= 1:
+        return f"__vm_engine has only {n} indirectbr(s) — dispatch was not inlined per-handler"
+    return None
+
+
+@register("vm_no_threaded_dispatch")
+def vm_no_threaded_dispatch(ir: str) -> Optional[str]:
+    # Inverse of vm_threaded_no_central_dispatch — proves the central
+    # vm.dispatch/vm.fetch pair (and its single indirectbr) is intact when
+    # threadedDispatch=0.
+    if not re.search(r"\bvm\.fetch\b", ir):
+        return "vm.fetch block not found — central dispatch pair missing"
+    engine = extract_fn_body(ir, "__vm_engine")
+    if engine is None:
+        return "__vm_engine function body not found"
+    n = len(re.findall(r"\bindirectbr\b", engine))
+    if n != 1:
+        return f"__vm_engine has {n} indirectbr(s), expected exactly 1 (central dispatch)"
+    return None


### PR DESCRIPTION
## VM pass hardening — round 2

Continues the VM hardening effort. Six feature commits plus two chore commits; all features gated behind a default-**OFF** knob and byte-identical to `main` when off. Full `--category vm --seeds 1,2,3` runtime suite: **88/88 PASS** on the final tree.

### What ships (features, all default off)

| Knob | Commit | What it does |
|------|--------|--------------|
| `lazyDecrypt` | `82bf1d1` | AES layer removed per-fetch into a per-call scratch window instead of decrypting the whole bytecode in the load constructor. The runtime bytecode buffer stays AES ciphertext at rest. Requires `useAES + encBytecode`. |
| `constInStream` | `a375bf1` | Integer, i64 and float constants moved out of plaintext wrapper stores into an encrypted-bytecode `OP_LOADI/OP_LOADI64/OP_LOADI_F` prologue. Adds `OP_LOADI64`; `OP_COUNT` grows `0x33 → 0x34`. Pointer constants stay in the wrapper (relocations). Requires `encBytecode`. |
| `nestedVM` + `nestedVMOpcodes` | `399e52e`, `bfade07` | Handler compute for `BINOP / BINOP64 / ICMP / ICMP64 / FCMP / CAST / BINOP_F` outlined into pure `__vm_h_<op>` helpers that are themselves virtualized against a second distinct engine (`__vm_engine.nest` vs plain `__vm_engine`). Depth-2 interpretation on hot arithmetic; the two-engine split makes recursion structurally impossible. `nestedVMOpcodes` caps how many opcodes nest in a fixed order. |
| `threadedDispatch` | `cca2185` | The shared `vm.dispatch`/`vm.fetch` pair is replaced by a per-handler tail: every handler ends with its own fetch + decode + `indirectbr`. No central dispatch block remains, so the "one urem + one GEP + one indirectbr" signature no longer describes the engine. |
| `keyedDispatch` | `76a30b5` | Every opcode byte written by the emitter is XOR'd with a compile-time key `K(salt, IP)`; both fetch paths (central + threaded) and the verifier un-XOR before decoding. The same physical byte at two IPs decodes to different logical opcodes — the static byte→handler map goes away. `K` is a compile-time-known function of salt+IP: kills static pattern matching, not symbolic-execution lifting. |

Every feature composes with every other one; a full-stack case
(`keyedDispatch + threadedDispatch + encDispatch + lazyDecrypt + constInStream + nestedVM + useAES`) is exercised end-to-end in the runtime suite.

### Infrastructure changes visible on the merge

- `VMImpl` decoupled from `VMCtx`: constructible from an explicit `VMPassConfig + Rng&`, so the pass can virtualize compiler-authored helper functions with no annotation. Required by nested-VM; harmless for every existing caller.
- `SharedState` and engine lookup keyed by `(Module*, EngineId)` — supports the two-engine layout.
- Verifier gained default-off parameters (`SaltFull`, `BlindTargets`, `KeyedDispatch`) so extra opcodes and key layers stay verifiable without touching other callers.
- Emitter gained `setConstInStream`, `setKeyedDispatch`; `bop()` records write IPs so the const-in-stream splice can re-key body opcode bytes after the shift.
- Runtime suite (`utils/cases`, `utils/gates`) extended with per-feature presets, cases and feature-active gates (`vm_lazydecrypt_*`, `vm_constinstream_*`, `vm_nestedvm_*`, `vm_threaded_*`, `vm_keyeddisp_*`) plus inverted off-path gates on the baseline case.

### Deferred, documented

- `nestedVMHardened` reserved but off — running the standard wrapper-hardening pipeline over the helper's thin wrapper currently produces a dominance-invalid IR (`%obf.salt.fr` used across blocks). Reproducible, isolated to the helper wrapper, not blocking; left with an in-code note.
- `CAST64 / SELECT / SELECT_F / FCAST_*` nesting: mixed-reg-file, low ROI vs cost — skipped intentionally.

### Test status on the tip of the branch

- Full `--category vm --seeds 1,2,3` = **88/88 PASS** (baseline 74 + 14 new feature cases across all knobs, incl. hardened/composition/determinism).
- Off-path (every knob `=0`): baseline `rt_vm_v7_*` cases pass unchanged; inverted gates on `rt_vm_v7_basic` confirm the new engines and IR markers are absent.
