### PR TITLE
Feat/vm hardening 3

### DIFF
--- a/VMPass.cpp
+++ b/VMPass.cpp
@@ -125,6 +125,7 @@ VMPassConfig VMPassConfig::fromPassConfig(const PassConfig& PC) {
 	getBool("keyedDispatch", Cfg.keyedDispatch);
 	getBool("superOps", Cfg.superOps);
 	getBool("randISA", Cfg.randISA);
+	getUInt("enginePoolSize", Cfg.enginePoolSize);
 
 	// lazyDecrypt requires encBytecode — nothing to defer if bytecode isn't encrypted.
 	if (!Cfg.encBytecode) Cfg.lazyDecrypt = false;
@@ -139,6 +140,7 @@ VMPassConfig VMPassConfig::fromPassConfig(const PassConfig& PC) {
 	if (!Cfg.hardened || !Cfg.antiDebug) Cfg.bindAntiDebug = false;
 	if (Cfg.handlerVariants < 1) Cfg.handlerVariants = 1;
 	if (Cfg.handlerVariants > kMaxHandlerVariants) Cfg.handlerVariants = kMaxHandlerVariants;
+	if (Cfg.enginePoolSize < 1) Cfg.enginePoolSize = 1;
 	return Cfg;
 }
 

--- a/VMPass.cpp
+++ b/VMPass.cpp
@@ -127,6 +127,7 @@ VMPassConfig VMPassConfig::fromPassConfig(const PassConfig& PC) {
 	getBool("randISA", Cfg.randISA);
 	getUInt("enginePoolSize", Cfg.enginePoolSize);
 	getBool("metamorphicEngines", Cfg.metamorphicEngines);
+	getBool("perFnEngine", Cfg.perFnEngine);
 
 	// lazyDecrypt requires encBytecode — nothing to defer if bytecode isn't encrypted.
 	if (!Cfg.encBytecode) Cfg.lazyDecrypt = false;
@@ -142,8 +143,9 @@ VMPassConfig VMPassConfig::fromPassConfig(const PassConfig& PC) {
 	if (Cfg.handlerVariants < 1) Cfg.handlerVariants = 1;
 	if (Cfg.handlerVariants > kMaxHandlerVariants) Cfg.handlerVariants = kMaxHandlerVariants;
 	if (Cfg.enginePoolSize < 1) Cfg.enginePoolSize = 1;
-	// metamorphicEngines needs a pool of >1 engine to diversify across.
-	if (Cfg.enginePoolSize < 2) Cfg.metamorphicEngines = false;
+	// metamorphicEngines needs >1 engine to diversify across -- either an
+	// explicit pool or per-function engines.
+	if (Cfg.enginePoolSize < 2 && !Cfg.perFnEngine) Cfg.metamorphicEngines = false;
 	return Cfg;
 }
 

--- a/VMPass.cpp
+++ b/VMPass.cpp
@@ -86,6 +86,8 @@ VMPassConfig VMPassConfig::fromPassConfig(const PassConfig& PC) {
 			Cfg.rollingRegKey = true;
 			Cfg.bindAntiDebug = true;
 			Cfg.randISA = true;
+			Cfg.perFnEngine = true;         // dedicated engine per virtualized fn
+			Cfg.metamorphicEngines = true;  // distinct handler body per engine
 		}
 		// Unknown preset name: silently ignore, falls through to defaults +
 		// explicit knobs.

--- a/VMPass.cpp
+++ b/VMPass.cpp
@@ -126,6 +126,7 @@ VMPassConfig VMPassConfig::fromPassConfig(const PassConfig& PC) {
 	getBool("superOps", Cfg.superOps);
 	getBool("randISA", Cfg.randISA);
 	getUInt("enginePoolSize", Cfg.enginePoolSize);
+	getBool("metamorphicEngines", Cfg.metamorphicEngines);
 
 	// lazyDecrypt requires encBytecode — nothing to defer if bytecode isn't encrypted.
 	if (!Cfg.encBytecode) Cfg.lazyDecrypt = false;
@@ -141,6 +142,8 @@ VMPassConfig VMPassConfig::fromPassConfig(const PassConfig& PC) {
 	if (Cfg.handlerVariants < 1) Cfg.handlerVariants = 1;
 	if (Cfg.handlerVariants > kMaxHandlerVariants) Cfg.handlerVariants = kMaxHandlerVariants;
 	if (Cfg.enginePoolSize < 1) Cfg.enginePoolSize = 1;
+	// metamorphicEngines needs a pool of >1 engine to diversify across.
+	if (Cfg.enginePoolSize < 2) Cfg.metamorphicEngines = false;
 	return Cfg;
 }
 

--- a/VMPass_Dispatch.cpp
+++ b/VMPass_Dispatch.cpp
@@ -540,6 +540,10 @@ void VMImpl::populateVMEngine() {
 	// Make the K structurally-identical variants distinct (per-variant MBA).
 	diversifyHandlerVariants(EF);
 
+	// Make this pool clone's handler bodies distinct from the other engines'
+	// (per-clone MBA, seeded by EngineId). No-op unless metamorphicEngines is on.
+	metamorphRewriteEngine(EF);
+
 	SS->NumVariants = NumVariants;
 	SS->EncDispatch = EncDispatch;
 	SS->LazyMode = LazyDecrypt;

--- a/VMPass_Harden.cpp
+++ b/VMPass_Harden.cpp
@@ -455,3 +455,97 @@ void VMImpl::diversifyHandlerVariants(Function* EF) {
 		errs() << "[vm] variant-diversify: " << Rewrites
 		<< " MBA rewrites (" << NumVariants << " variants)\n";
 }
+
+
+// ============================================================================
+// metamorphRewriteEngine (engine-pool metamorphism, P10)
+//
+// diversifyHandlerVariants makes the K variant COPIES within one engine
+// distinct; this makes the N ENGINES of the pool distinct from each other.
+// Every integer handler binop (in any VariantOf-tagged block) is rewritten
+// with a semantics-preserving MBA identity chosen from a per-CLONE RNG seeded
+// by this engine's pool identity (EngineId) and the module seed -- NOT the
+// founding function's RNG -- so two engines get different rewrites regardless
+// of which function happened to build each, and even when handlerVariants=1
+// and hardened=0 would otherwise leave the bodies byte-for-byte identical.
+//
+// Runs for every engine (including pool 0) when MetamorphicEngines is on;
+// off (the default, and forced off unless enginePoolSize>1) it is never
+// called, so the build is byte-identical. Placed right after
+// diversifyHandlerVariants in populateVMEngine -- same window: handler blocks
+// built, VariantOf valid, dispatch not yet emitted (so the urem/IP arithmetic
+// a lifter fingerprints is untouched -- only opcode-compute blocks are here).
+// ============================================================================
+void VMImpl::metamorphRewriteEngine(Function* EF) {
+	if (!EF || !MetamorphicEngines) return;
+
+	// Per-clone seed: module-uniform MasterSeed mixed with this engine's pool
+	// identity. Independent of the founding function's RNG so the divergence is
+	// keyed on the clone, deterministically and reproducibly.
+	obf::Rng MetaRng(obf::mix64(MasterSeed ^ obf::fnv1a64("vm.metamorph.engine")
+		^ ((uint64_t)EngineId * 0x9E3779B97F4A7C15ull)));
+	llvm::obf::MbaUtils   MBA(M, MetaRng, "obf.vm.metamorph.mba.i32");
+	llvm::obf::OpaqueUtils Opaque(M, MetaRng, "vm.metamorph.opaque.i32");
+
+	SmallVector<BinaryOperator*, 256> Cands;
+	for (BasicBlock& BB : *EF) {
+		if (VariantOf.find(&BB) == VariantOf.end()) continue; // handler blocks only
+		for (Instruction& I : BB) {
+			if (auto* BO = dyn_cast<BinaryOperator>(&I)) {
+				if (!BO->getType()->isIntegerTy()) continue;
+				if (!llvm::obf::MbaUtils::isTargetOpcode(BO->getOpcode())) continue;
+				Cands.push_back(BO);
+			}
+		}
+	}
+
+	unsigned Rewrites = 0;
+	for (BinaryOperator* BO : Cands) {
+		if (!BO->getParent()) continue; // already erased
+		IRBuilder<> B(BO);
+		Value* A = BO->getOperand(0);
+		Value* V = BO->getOperand(1);
+		unsigned pick = MetaRng.u32();   // per-clone identity choice at this site
+		Value* Rv = nullptr;
+		switch (BO->getOpcode()) {
+		case Instruction::Add:
+			switch (pick % 3) { case 0: Rv = MBA.add(B, A, V); break;
+							    case 1: Rv = MBA.addAlt(B, A, V); break;
+							    default: Rv = MBA.addAlt2(B, A, V); } break;
+		case Instruction::Sub:
+			switch (pick % 3) { case 0: Rv = MBA.sub(B, A, V); break;
+							    case 1: Rv = MBA.subAlt(B, A, V); break;
+							    default: Rv = MBA.subAlt2(B, A, V); } break;
+		case Instruction::Or:
+			switch (pick % 3) { case 0: Rv = MBA.bitwiseOr(B, A, V); break;
+							    case 1: Rv = MBA.bitwiseOrAlt(B, A, V); break;
+							    default: Rv = MBA.bitwiseOrAlt2(B, A, V); } break;
+		case Instruction::And:
+			Rv = (pick % 2) ? MBA.bitwiseAndAlt(B, A, V) : MBA.bitwiseAnd(B, A, V); break;
+		case Instruction::Xor:
+			Rv = (pick % 2) ? MBA.bitwiseXorAlt(B, A, V) : MBA.bitwiseXor(B, A, V); break;
+		default: break;
+		}
+		if (!Rv) continue;
+
+		// Per-site opaque-zero XOR (matches diversify's noise pattern + width
+		// handling) so repeated identities still diverge and resist -O2 folding.
+		Value* Z = Opaque.opaqueZero32(B);
+		Type* RT = Rv->getType();
+		if (RT != Z->getType()) {
+			if (RT->getIntegerBitWidth() > 32) Z = B.CreateZExt(Z, RT, "me.z.ext");
+			else                                Z = B.CreateTrunc(Z, RT, "me.z.tr");
+		}
+		Rv = B.CreateXor(Rv, Z, "me.noise");
+
+		BO->replaceAllUsesWith(Rv);
+		BO->eraseFromParent();
+		++Rewrites;
+	}
+
+	LLVM_DEBUG(dbgs() << "[vm] metamorphRewriteEngine(EngineId=" << EngineId
+		<< "): " << Rewrites << " per-clone MBA rewrites\n");
+	if (ObfVerbose)
+		errs() << "[vm] metamorph-engine(id=" << EngineId << "): "
+		<< Rewrites << " MBA rewrites\n";
+}

--- a/VMPass_Nested.cpp
+++ b/VMPass_Nested.cpp
@@ -547,7 +547,14 @@ Function* VMImpl::getOrCreateNestedBinopFHelper() {
 // the fixed nesting order; a helper not found by name was never referenced
 // (opcodeNests() excluded it, e.g. via the nestedVMOpcodes cap).
 void VMImpl::virtualizeNestedHelpersOnce() {
-	VMEngine::SharedState* SS = VMEngine::getSharedState(M, EngineId);
+	// There is one shared set of __vm_h_* helpers per module, all virtualized
+	// against the plain pool-0 engine (EngineId 0). With a pooled nest layer the
+	// module can hold several nest engines (@__vm_engine.nest[.pN], one per pool
+	// member a nestedVM function landed in), and each would otherwise re-enter
+	// here and virtualize the same helpers again -- wrapping an already-wrapped
+	// helper. Key the once-guard on the plain pool-0 engine's state, which every
+	// nest engine shares, so the helpers are virtualized exactly once per module.
+	VMEngine::SharedState* SS = VMEngine::getSharedState(M, VMEngine::makeEngineId(0, 0));
 	if (SS->NestedHelpersBuilt) return;
 	SS->NestedHelpersBuilt = true;
 

--- a/docs/VM.md
+++ b/docs/VM.md
@@ -35,12 +35,19 @@ configuration reference, interaction with other passes, debugging, and known lim
 - [Opcode permutation](#opcode-permutation)
 - [Hardening layers](#hardening-layers)
   - [Layer 1 — Register-index XOR (obfRegIdx)](#layer-1--register-index-xor-obfregidx)
-  - [Layer 2a — LCG bytecode encryption (encBytecode, useAES=0)](#layer-2a--lcg-bytecode-encryption-encbytecode-useaes0)
-  - [Layer 2b — AES-128-CTR bytecode encryption (useAES=1)](#layer-2b--aes-128-ctr-bytecode-encryption-useaes1)
+  - [Layer 2 — AES-128-CTR bytecode encryption (encBytecode)](#layer-2--aes-128-ctr-bytecode-encryption-encbytecode)
   - [Layer 3 — Register-value XOR (regEncrypt)](#layer-3--register-value-xor-regencrypt)
   - [Layer 4 — Structural hardening (hardened=1)](#layer-4--structural-hardening-hardened1)
   - [Layer 5 — Anti-debug timing gates (antiDebug)](#layer-5--anti-debug-timing-gates-antidebug)
+- [Structural virtualisation features](#structural-virtualisation-features)
+  - [Nested virtualisation (nestedVM)](#nested-virtualisation-nestedvm)
+  - [Threaded dispatch (threadedDispatch)](#threaded-dispatch-threadeddispatch)
+  - [IP-keyed dispatch (keyedDispatch)](#ip-keyed-dispatch-keyeddispatch)
+  - [Super-operators (superOps)](#super-operators-superops)
+  - [Per-build ISA randomisation (randISA)](#per-build-isa-randomisation-randisa)
+  - [Engine pool and metamorphic engines](#engine-pool-and-metamorphic-engines)
 - [Configuration reference](#configuration-reference)
+  - [Presets](#presets)
 - [Interaction with other passes](#interaction-with-other-passes)
 - [Eligibility and skip reasons](#eligibility-and-skip-reasons)
 - [Performance considerations](#performance-considerations)
@@ -83,12 +90,21 @@ interpreter (rendered from the obfuscator's own CFG report):
 
 ### Module-level shared engine
 
-All 51 opcode handlers live in a **single module-level function** `__vm_engine()`.
-This function is created once per module and populated on first use, so the handler
-code is **not duplicated** for each virtualised function — only the thin wrapper and
+All 53 opcode handlers live in a **shared engine function** `__vm_engine()`.
+By default a single engine is created once per module and populated on first use, so the
+handler code is **not duplicated** for each virtualised function — only the thin wrapper and
 per-function globals are unique per function.
 
-`__vm_engine` signature (18 parameters, all by value or pointer):
+> **Engine pool and per-function engines.** A build can instead spread functions across
+> *several* structurally-distinct engines (`enginePoolSize=N`), give a function its own
+> private engine (`perFnEngine=1`), or diversify every engine's handler bodies
+> (`metamorphicEngines=1`). Nested virtualisation (`nestedVM=1`) adds a second engine layer.
+> See [Engine pool and metamorphic engines](#engine-pool-and-metamorphic-engines) and
+> [Nested virtualisation](#nested-virtualisation-nestedvm). The single-engine layout
+> described here is the `enginePoolSize=1` default.
+
+`__vm_engine` signature (18 parameters, or 19 with the trailing `lazyctx` under `lazyDecrypt`;
+all by value or pointer):
 
 | Param # | Name | Type | Purpose |
 |---|---|---|---|
@@ -211,27 +227,33 @@ After bytecode emission, `VMImpl::run()` calls these builders in order:
 
 1. `buildBytecodeGlobal()` — create `@fn.vm.bytecode` constant (unencrypted at this point).
 2. `buildCalleeGlobal()` — create `@fn.vm.callees` constant.
-3. Ensure `__vm_engine` exists (`VMEngine::getOrBuildVMEngine`).
-4. If not yet populated: `populateVMEngine()` → `buildOpcodeHandlers()` (six groups),
-   `buildHandlerTable()`, `buildDispatch()`.
-5. `buildVMEntry()` — replace the original function body with the wrapper.
-6. `buildHandlerTable()` — emit the per-function permuted `@fn.vm.ophandlers` constant.
-7. Encryption constructors: `buildEncryptCtorAES()` or `buildEncryptCtorLCG()`.
-8. If `hardened=1`:
-   - `hardenWrapper()` — split + junk + opaque predicates on the wrapper.
-   - `mbaHardenWrapper()` — MBA on wrapper arithmetic.
-   - `flattenWrapper()` — switch-dispatch flattening of the wrapper.
-   - `hardenVMEngine()` — MBA and opaque preds inside the shared engine.
-   - `buildAntiDebugGate()` — RDTSC timing traps.
-   - `buildIntegrityHashCtor()` — FNV-1a bytecode integrity check.
-   - `buildCalleeXorCtor()` — callee XOR masking in `.init_array`.
+3. Under `nestedVM`: create the `__vm_h_*` helper functions (plain bodies) so handler cases can
+   emit calls to them.
+4. Select this function's engine (`EngineId`, derived from its pool index and the nested/plain
+   layer) and ensure it exists (`getOrBuildVMEngine`).
+5. If that engine is not yet populated: `populateVMEngine()` → `buildOpcodeHandlers()` (six
+   groups) → `diversifyHandlerVariants()` → `metamorphRewriteEngine()` (per-clone body rewrite
+   under `metamorphicEngines`) → `buildDispatch()` → (hardened) `hardenVMEngine()`.
+6. Under `nestedVM`: `virtualizeNestedHelpersOnce()` — inner-virtualise the shared helpers once
+   per module, against the plain pool-0 engine.
+7. `buildHandlerTable()` — emit the per-function permuted `@fn.vm.ophandlers` constant.
+8. `buildVMEntry()` — replace the original function body with the wrapper.
+9. Encryption constructor: `buildEncryptCtor()` (AES-128-CTR; under `lazyDecrypt` the whole-buffer
+   decrypt is elided in favour of per-fetch keystream blocks).
+10. Under `bindAntiDebug`: `buildAntiDebugKeyBindCtor()` — priority-100 ctor that folds
+    debugger detection into the AES round-key mask.
+11. If `hardened=1`: `hardenWrapper()` (split + junk + opaque predicates), `mbaHardenWrapper()`
+    (MBA on wrapper arithmetic), `flattenWrapper()` (switch-dispatch flattening),
+    `buildAntiDebugGate()` (RDTSC timing traps), `buildIntegrityHashCtor()` (FNV-1a bytecode
+    integrity check), and `buildCalleeXorCtor()` (callee XOR masking in `.init_array`).
 
 ---
 
 ## ISA reference
 
-The ISA has **51 logical opcodes** (`OP_COUNT = 0x33`), variable-width encoding,
-and little-endian multi-byte immediates.
+The ISA has **53 logical opcodes** (`OP_COUNT = 0x35`), variable-width encoding,
+and little-endian multi-byte immediates. (The two most recent additions are
+`OP_LOADI64` = 0x33, used by `constInStream`, and `OP_MULADD` = 0x34, used by `superOps`.)
 
 Physical opcode bytes in the bytecode stream are **not** the logical VMOp values — they are
 passed through a per-function permutation (see [Opcode permutation](#opcode-permutation)).
@@ -259,6 +281,7 @@ passed through a per-function permutation (see [Opcode permutation](#opcode-perm
 | `OP_STOREPTR` | 0x20 | `opc valp:u8 ptrreg:u8` (3 B) | Store pointer to address in preg. |
 | `OP_SELECT` | 0x12 | `opc kind:u8 dst:u8 cond:u8 t:u8 f:u8` (6 B) | Ternary select across register files. |
 | `OP_PTRTOINT64` | 0x13 | `opc dst64:u8 srcp:u8` (3 B) | `ptrtoint` preg → vreg64 (i64). |
+| `OP_MULADD` | 0x34 | `opc dst:u8 a:u8 b:u8 c:u8` (5 B) | Fused `dst = a*b + c` (i32). Emitted by `superOps` in place of a `mul`+`add` pair. |
 
 </details>
 
@@ -273,6 +296,7 @@ passed through a per-function permutation (see [Opcode permutation](#opcode-perm
 | `OP_BINOP64` | 0x17 | `opc dst64:u8 a64:u8 b64:u8 subop:u8` (5 B) | Binary op on vreg64 file. Same BinSubop encoding. |
 | `OP_ICMP64` | 0x1A | `opc dst:u8 a64:u8 b64:u8 pred:u8` (5 B) | 64-bit integer compare; result → vreg (i32). |
 | `OP_GEP64` | 0x19 | `opc dstp:u8 basep:u8 idx64:u8 elemsz:u16le` (6 B) | GEP with 64-bit index. |
+| `OP_LOADI64` | 0x33 | `opc dst64:u8 imm:i64le` (10 B) | Load 64-bit immediate into vreg64. Emitted by `constInStream` to carry i64 constants inside the encrypted bytecode prologue instead of a plaintext wrapper store. |
 
 </details>
 
@@ -422,9 +446,11 @@ is rounded back to f32 precision via fptrunc→fpext before being stored).
 | Opcode | Bytes | Layout |
 |---|---|---|
 | `OP_LOADI` | 6 | `opc dst imm0 imm1 imm2 imm3` |
+| `OP_LOADI64` | 10 | `opc dst64 imm0 imm1 imm2 imm3 imm4 imm5 imm6 imm7` |
 | `OP_LOADI_F` | 10 | `opc dst f0 f1 f2 f3 f4 f5 f6 f7` |
 | `OP_MOVR` | 3 | `opc dst src` |
 | `OP_BINOP` | 5 | `opc dst a b subop` |
+| `OP_MULADD` | 5 | `opc dst a b c` |
 | `OP_ICMP` | 5 | `opc dst a b pred` |
 | `OP_CAST` | 4 | `opc dst src kind` |
 | `OP_PTRTOINT` | 3 | `opc dst srcp` |
@@ -450,7 +476,7 @@ is rounded back to f32 precision via fptrunc→fpext before being stored).
 ## Opcode permutation
 
 Each virtualised function gets a **unique logical↔physical opcode bijection** stored in
-`@<fn>.vm.ophandlers`. The bijection is a Fisher-Yates shuffle over all 51 opcodes, seeded
+`@<fn>.vm.ophandlers`. The bijection is a Fisher-Yates shuffle over all 53 opcodes, seeded
 from the per-function RNG:
 
 ```cpp
@@ -496,35 +522,31 @@ A static analyst sees a register access with an index that depends on a volatile
 
 To disable: `obfRegIdx=0`.
 
-### Layer 2a — LCG bytecode encryption (`encBytecode=1, useAES=0`)
+### Layer 2 — AES-128-CTR bytecode encryption (`encBytecode`)
 
-A `.init_array` constructor encrypts `@<fn>.vm.bytecode` in-place before `main()` using an
-LCG keystream:
+**Default: on.** AES-128-CTR is the only bytecode cipher (the legacy LCG keystream path was
+removed — the `useAES` knob is now a no-op accepted for backward compatibility).
 
-```
-state = ptrtoint(@bytecode) XOR COMPILE_TIME_SEED
-for each byte: key = LCG_next(state); bytecode[i] ^= key
-```
+A per-function 128-bit AES key is generated from the RNG hierarchy at compile time. A
+`.init_array` constructor calls `__obf_aes_ctr_decrypt(key, nonce, bytecode, len)` — the same
+runtime stub shared with the `strenc` pass — to decrypt `@<fn>.vm.bytecode` in place before
+`main()`. The dispatch loop additionally re-derives each fetched opcode byte from the volatile
+salt and IP (see [IP-keyed dispatch](#ip-keyed-dispatch-keyeddispatch)).
 
-The key mixes ASLR (the load-time address of the global) with a compile-time seed, so the
-decrypted bytecode is different at every process invocation (ASLR is required on the target).
+**Lazy decryption (`lazyDecrypt=1`, requires `encBytecode`).** Instead of the ctor decrypting
+the whole buffer up front, the runtime bytecode stays ciphertext at rest and each fetched byte
+is decrypted on demand from a recomputed AES-CTR keystream block (`__obf_aes_ctr_keystream_block`).
+The engine gains a trailing `lazyctx` parameter (round key + nonce + keystream cache) that the
+wrapper allocates and unmasks per call, so a memory dump never sees the decrypted bytecode as a
+contiguous plaintext region. The per-byte keystream recompute is branchless (no CFG split), which
+is required because the fetch helpers must stay straight-line.
 
-The dispatch loop additionally decrypts each fetched opcode byte:
-
-```
-physical_opc = raw_byte ^ ((vm.salt ^ vm.ip) & 0xFF)
-```
-
-### Layer 2b — AES-128-CTR bytecode encryption (`useAES=1`)
-
-**Default: on.** Replaces the LCG layer.
-
-A per-function 128-bit AES key is generated from the RNG hierarchy at compile time.
-The `.init_array` constructor calls `__obf_aes_ctr_decrypt(key, nonce, bytecode, len)` —
-the same runtime stub shared with the `strenc` pass. This provides full AES-128-CTR
-strength for bytecode confidentiality.
-
-To fall back to LCG: `useAES=0`.
+**Constants in the stream (`constInStream=1`, requires `encBytecode`).** By default integer and
+floating-point constants are materialised by plaintext `store` instructions in the wrapper. With
+`constInStream` they are spliced into the encrypted bytecode as an `OP_LOADI` / `OP_LOADI64` /
+`OP_LOADI_F` prologue instead, so the constants live inside the AES-encrypted stream rather than
+in cleartext IR. Pointer constants stay in the wrapper (they carry relocations and are not
+secret).
 
 ### Layer 3 — Register-value XOR (`regEncrypt`)
 
@@ -573,11 +595,111 @@ Active when both `hardened=1` and `antiDebug=1`.
   `PoisonKey`, causing all subsequent register-index deobfuscation to produce wrong slots
   and silently corrupt execution.
 - **Handler spot-checks**: `adHandlerProb`% of handlers (default 10%) get an inline RDTSC
-  check against `adHandlerThreshold` (default 500 cycles). Exceeding the threshold again
-  triggers salt corruption.
+  check against `adHandlerThreshold` (default 5000 cycles). To avoid false positives from
+  ordinary scheduling noise, a trap poisons the salt only after **`kDebounce` consecutive**
+  slow executions (a latch prevents the self-inverse XOR from cancelling), so a lone timing
+  spike no longer corrupts a correct run.
 
 The salt-corruption approach produces silently wrong results rather than a crash or an
 exception, which makes debugging under a debugger harder to detect and diagnose.
+
+**Anti-debug bound into the key schedule (`bindAntiDebug=1`, requires `hardened`).** Instead
+of (or in addition to) the timing traps, a per-function `.init_array` constructor at priority
+100 — running *before* the AES-decrypt ctor — reads `IsDebuggerPresent`,
+`CheckRemoteDebuggerPresent`, and `NtQueryInformationProcess(ProcessDebugPort)` and XORs a
+`bit × ADPoisonKey` mask into the first 16 bytes of the masked AES round-key global. Under a
+debugger the AES key that decrypts the bytecode is wrong, so the bytecode decodes to garbage
+and the program crashes before the interpreter runs a single opcode; under a normal run the
+mask is untouched. When `bindAntiDebug` is on, the handler-level RDTSC traps are skipped
+entirely (they were the historical source of timing flakes).
+
+---
+
+## Structural virtualisation features
+
+These features change the *shape* of the interpreter itself — its dispatch, its ISA encoding,
+and how many engines exist — rather than layering encryption on top of a fixed interpreter.
+Each is behind its own knob (all default off unless noted) and each is byte-identical to the
+previous build when its knob is off. They compose with one another and with the hardening
+layers above.
+
+### Nested virtualisation (`nestedVM`)
+
+The compute step of several eligible opcodes (BINOP, BINOP64, ICMP, ICMP64, FCMP, CAST,
+BINOP_F) is outlined into a pure helper function `__vm_h_<op>` that is **itself virtualised**.
+Executing one such outer opcode therefore drives a whole inner interpreter loop — depth-2
+virtualisation on hot arithmetic.
+
+Recursion is made impossible by using two *distinct* engines rather than a runtime flag on one:
+the outer function targets `__vm_engine.nest` (whose eligible handlers *call* the helper), while
+every helper is virtualised against the plain `__vm_engine` (whose handlers compute inline). A
+helper's own arithmetic thus runs through the plain engine, which never calls back into a
+helper. The shared `__vm_h_*` helper set is virtualised exactly once per module.
+
+- `nestedVMOpcodes` — `0` nests all eligible opcodes; `N>0` nests only the first `N` in the
+  fixed order above.
+- `nestedVMHardened` — reserved (hardening the tiny helper wrapper currently yields a
+  dominance-invalid rewrite; left off).
+
+### Threaded dispatch (`threadedDispatch`)
+
+Removes the single central `vm.dispatch` / `vm.fetch` pair. Every handler instead ends with its
+own inlined fetch + decode + `indirectbr` tail, so the classic "one `urem`, one GEP, one
+`indirectbr`" central-loop fingerprint disappears. The nested-VM inner engine inherits threaded
+dispatch from the outer config, so both engines are threaded consistently.
+
+### IP-keyed dispatch (`keyedDispatch`)
+
+Each opcode byte is XOR'd at emit time with a per-IP compile-time key `K(salt, IP) =
+((salt·(IP+1)) ⊕ (salt≫8)) & 0xFF`, and un-XOR'd at fetch time (in both the central and threaded
+paths, and in the verifier). The *same* physical byte at two different IPs therefore decodes to
+different logical opcodes, so a static byte→handler map no longer holds. This is a compile-time
+key, not cryptography: it defeats static byte-signature matching, not a symbolic-execution
+lifter. (When composed with `constInStream`, body opcode bytes are re-keyed after the prologue
+splice shifts their IPs.)
+
+### Super-operators (`superOps`)
+
+Recognises `%m = mul i32 %a,%b; %d = add i32 %m,%c` chains (where the `mul` is consumed only by
+the `add`) and fuses them into a single `OP_MULADD` opcode computing `a*b + c`. Lifting the
+handler no longer recovers a bare `mul` or `add` primitive. Emission is anchored at the `add`'s
+position so SSA dominance guarantees all inputs are available.
+
+### Per-build ISA randomisation (`randISA`)
+
+Complements the per-function [opcode permutation](#opcode-permutation): where that permutes the
+*opcode* byte per function, `randISA` permutes the *operand-field encodings* per **build**,
+module-uniformly. Two builds of the same source at different seeds then share no static handler
+signature for the permuted families, because the shared-engine switch/select-chain constants —
+and the emitted operand bytes — differ. Five families are permuted: **BinSubop** (integer
+`OP_BINOP`/`OP_BINOP64`), **ICmp predicates**, **CastKind**, **FBinSubop** (float arithmetic,
+preserving the f32 flag bit), and **FCmp predicates**. Each family draws from its own
+seed-derived RNG, so the maps are independent. The permutation is derived from the module seed
+(not the per-function RNG), so the shared handler, every per-function emitter, and the nested
+helpers all agree.
+
+### Engine pool and metamorphic engines
+
+By default one shared engine serves the whole module — lift it once and every virtualised
+function is understood. These knobs raise that per-lift *multiplier*:
+
+- **`enginePoolSize=N`** — build `N` structurally-distinct engines per module and assign each
+  function to one deterministically (by a hash of its name and the module seed). Engines are
+  named `__vm_engine`, `__vm_engine.p1`, `__vm_engine.p2`, … (and, under `nestedVM`,
+  `__vm_engine.nest`, `__vm_engine.nest.p1`, …). Lifting one function's engine gives no shortcut
+  for a function that runs a different one. Cost scales roughly linearly (~30 KB `.text` per
+  engine).
+- **`metamorphicEngines=1`** (requires a pool, or `perFnEngine`) — rewrites each engine's integer
+  handler arithmetic with semantics-preserving MBA identities chosen from a *per-engine* seed, so
+  the pool engines have structurally **distinct handler bodies**, not just distinct names — even
+  when `handlerVariants=1` and `hardened=0` would otherwise leave the bodies identical.
+- **`perFnEngine=1`** — give *this* function its own private engine (a wide per-function hash id)
+  instead of hashing it into the pool. Because annotations are per-function, setting it on
+  selected critical functions gives them dedicated engines while the rest share the pool
+  (annotation-selective); setting it everywhere yields a full per-function engine build. Highest
+  structural resilience, highest `.text` cost.
+
+`preset=max` turns on `perFnEngine` + `metamorphicEngines` (see below).
 
 ---
 
@@ -589,20 +711,54 @@ Annotation syntax:
 __attribute__((annotate("obf: vm(<params>)")))
 ```
 
+A `preset=<light|medium|high|max>` bundle (below) is the easy way in; the individual knobs are:
+
 | Parameter | Default | Range | Description |
 |---|---|---|---|
+| `preset` | — | light/medium/high/max | Canned knob bundle applied before explicit knobs (which override it). See [Presets](#presets). |
 | `minBlocks` | 1 | 1–∞ | Skip if the function has fewer than N basic blocks. |
 | `maxBlocks` | 400 | 0–∞ | Skip if the function has more than N blocks. 0 = no upper limit. |
-| `useAES` | 1 | 0/1 | Use AES-128-CTR for layer-2 bytecode encryption. 0 = LCG fallback. |
 | `obfRegIdx` | 1 | 0/1 | XOR register-index bytes with compile-time salt (layer 1). |
-| `encBytecode` | 1 | 0/1 | Emit `.init_array` constructor to encrypt bytecode at load time. |
-| `hardened` | 0 | 0/1 | Enable layer-4 structural hardening + layer-5 anti-debug. |
-| `regEncrypt` | 0 | 0/1 | Enable per-slot register-value XOR encryption (layer 3). |
-| `antiDebug` | 1 | 0/1 | Enable RDTSC anti-debug timing gates (requires `hardened=1`). |
+| `encBytecode` | 1 | 0/1 | AES-encrypt the bytecode via a load-time `.init_array` ctor (layer 2). |
+| `lazyDecrypt` | 0 | 0/1 | Decrypt bytecode per-fetch instead of whole-buffer; keeps it ciphertext at rest. Requires `encBytecode`. |
+| `constInStream` | 0 | 0/1 | Carry int/i64/fp constants inside the encrypted bytecode instead of plaintext wrapper stores. Requires `encBytecode`. |
+| `regEncrypt` | 0 | 0/1 | Per-slot register-value XOR encryption (layer 3). |
+| `rollingRegKey` | 0 | 0/1 | Evolve the register XOR key as the interpreter runs (with `regEncrypt`). |
+| `hardened` | 0 | 0/1 | Layer-4 structural hardening + layer-5 anti-debug. |
+| `handlerVariants` | 3 | 1–K | Number of structurally-distinct handler-body copies per opcode. |
+| `encDispatch` | 1 | 0/1 | Route dispatch through an encrypted opcode-index map. |
+| `strongBytecode` | 1 | 0/1 | Stronger bytecode obfuscation. |
+| `blindTargets` | 1 | 0/1 | Blind branch/switch targets in the stream. |
+| `threadedDispatch` | 0 | 0/1 | Inline fetch/decode/`indirectbr` into every handler; no central dispatch. |
+| `keyedDispatch` | 0 | 0/1 | XOR each opcode byte with a per-IP compile-time key. |
+| `superOps` | 0 | 0/1 | Fuse `mul`+`add` chains into `OP_MULADD`. |
+| `randISA` | 0 | 0/1 | Per-build permutation of operand-field byte encodings (5 families). |
+| `nestedVM` | 0 | 0/1 | Virtualise eligible opcode handlers against a second engine. |
+| `nestedVMOpcodes` | 0 | 0–7 | Cap on how many opcodes nest (0 = all eligible). |
+| `enginePoolSize` | 1 | 1–∞ | Build N distinct engines and spread functions across them. |
+| `metamorphicEngines` | 0 | 0/1 | Per-clone MBA rewrite so pool engines have distinct bodies. Requires a pool or `perFnEngine`. |
+| `perFnEngine` | 0 | 0/1 | Give this function its own dedicated engine. |
+| `antiDebug` | 1 | 0/1 | RDTSC anti-debug timing gates (requires `hardened=1`). |
+| `bindAntiDebug` | 0 | 0/1 | Fold anti-debug detection into the AES key mask (requires `hardened`+`antiDebug`). |
 | `adDispatchThreshold` | 5000 | — | RDTSC cycle delta for dispatch-level gate. |
-| `adHandlerThreshold` | 500 | — | RDTSC cycle delta for per-handler spot checks. |
+| `adHandlerThreshold` | 5000 | — | RDTSC cycle delta for per-handler spot checks (debounced). |
 | `adDispatchInterval` | 64 | — | Check every N fetch iterations. Must be a power of 2. |
 | `adHandlerProb` | 10 | 0–100 | Percentage of handlers equipped with timing traps. |
+
+> The legacy `useAES` knob was removed — AES-128-CTR is now the only bytecode cipher.
+> `useAES=…` in an annotation is silently ignored.
+
+### Presets
+
+`preset=<name>` resolves to a knob bundle *before* explicit knobs are parsed, so any explicit
+knob still overrides the preset:
+
+| Preset | Bundle |
+|---|---|
+| `light` | Structural virtualisation only — `obfRegIdx`, `encBytecode`, `handlerVariants=1`. |
+| `medium` | Today's defaults — `handlerVariants=3`, `encDispatch`, `strongBytecode`, `blindTargets`. Bit-identical to a bare `vm(...)`. |
+| `high` | `medium` + `hardened` + `threadedDispatch` + `keyedDispatch`. |
+| `max` | `high` + `lazyDecrypt` + `constInStream` + `nestedVM` + `superOps` + `rollingRegKey` + `bindAntiDebug` + `randISA` + `perFnEngine` + `metamorphicEngines`. |
 
 **Usage examples:**
 
@@ -611,21 +767,25 @@ __attribute__((annotate("obf: vm(<params>)")))
 __attribute__((annotate("obf: vm")))
 int fn(int x) { return x; }
 
-// Disable AES, use LCG fallback (lighter, weaker)
-__attribute__((annotate("obf: vm(useAES=0)")))
-int fn2(int x) { return x; }
+// Strongest single-annotation tier: full stack, per-function metamorphic engines
+__attribute__((annotate("obf: vm(preset=max)")))
+int fn2(int key, int data) { return key ^ data; }
 
-// Full hardening: AES + register encryption + structural hardening + anti-debug
-__attribute__((annotate("obf: vm(hardened=1, useAES=1, regEncrypt=1, antiDebug=1)")))
+// Full hardening with per-slot register encryption and anti-debug
+__attribute__((annotate("obf: vm(hardened=1, regEncrypt=1, antiDebug=1)")))
 int fn3(int key, int data) { return key ^ data; }
 
+// Structural diversity without hardening: 4-engine pool + metamorphic bodies + per-build ISA
+__attribute__((annotate("obf: vm(enginePoolSize=4, metamorphicEngines=1, randISA=1)")))
+int fn4(int x) { return x * 3 + 1; }
+
 // Tune anti-debug thresholds for a slower target (embedded, VM, etc.)
-__attribute__((annotate("obf: vm(hardened=1, antiDebug=1, adDispatchThreshold=50000, adHandlerThreshold=5000)")))
-int fn4(int x) { return x * 3; }
+__attribute__((annotate("obf: vm(hardened=1, antiDebug=1, adDispatchThreshold=50000, adHandlerThreshold=20000)")))
+int fn5(int x) { return x * 3; }
 
 // Skip small functions, cap at 200 blocks
 __attribute__((annotate("obf: vm(minBlocks=5, maxBlocks=200)")))
-int fn5(int a, int b, int c) { return a + b + c; }
+int fn6(int a, int b, int c) { return a + b + c; }
 ```
 
 ---
@@ -646,7 +806,7 @@ before they can apply any further analysis:
 
 ```c
 // Recommended: pre-obfuscate with mba + bcf, then virtualise
-__attribute__((annotate("obf: mba(prob=70,maxDepth=3), bcf(prob=30,loop=1), vm(hardened=1,useAES=1)")))
+__attribute__((annotate("obf: mba(prob=70,maxDepth=3), bcf(prob=30,loop=1), vm(hardened=1)")))
 int fn(int x, int y) { return x * y + (x ^ y); }
 ```
 
@@ -703,7 +863,11 @@ hardening level):
 |---|---|
 | Base (no hardening) | 5–20× slowdown vs. native |
 | `obfRegIdx=1` (default) | +5–15% over base |
-| `useAES=1` (load-time only) | Negligible runtime cost (`.init_array` overhead) |
+| `encBytecode=1` (whole-buffer AES) | Negligible runtime cost (`.init_array` overhead) |
+| `lazyDecrypt=1` (per-fetch AES) | +30–100% over base (one keystream block per operand byte) |
+| `nestedVM=1` | +2–10× over base (depth-2 interpretation of hot arithmetic) |
+| `enginePoolSize=N` / `perFnEngine` | Negligible runtime cost; ~30 KB `.text` per engine |
+| `metamorphicEngines=1` | Negligible runtime cost; larger engine `.text` (MBA-expanded handlers) |
 | `regEncrypt=1` | +20–50% over base (register access pattern) |
 | `hardened=1` | +15–30% over base (extra instructions in handlers) |
 | `antiDebug=1` | +1–5% over base (RDTSC checks, amortised) |
@@ -732,7 +896,7 @@ opt -passes=obfuscation -S test.ll -o test.obf.ll \
   -obf-seed=1 -obf-deterministic -obf-verify \
   -obf-report-dir=obf_report
 
-python llvm/utils/obfuscator/obf_report_html.py \
+python utils/obf_report_html.py \
   --json obf_report/obf_report.json \
   --out  obf_report/obf_report.html \
   --renderer dot
@@ -795,13 +959,22 @@ If the obfuscated function produces wrong results after a subsequent `-O2` pass:
 To add a new opcode:
 
 1. Add the new `VMOp` enumerator to `VMPass_ISA.h` **before** `OP_COUNT`. Bump `OP_COUNT`.
-2. Add the new `BinSubop` / `CastKind` / etc. sub-opcode if needed.
+2. Add the new `BinSubop` / `CastKind` / etc. sub-opcode if needed. If it is an operand-field
+   encoding you want `randISA` to permute, add a family to `ISAEnc` (`VMPass_ISA.h`) and encode
+   it at both the emitter and the handler switch/select-chain.
 3. Add the emission case in `BytecodeEmitter::emit(Instruction*)` in `VMPass_Emitter.cpp`.
-4. Add the handler `BasicBlock` in `VMImpl::buildOpcodeHandlers()` (choose the appropriate
-   group: `buildHandlersIntArith`, `buildHandlersMem`, etc.) in `VMPass_Impl.cpp`.
-5. Update the `VMPass_Verifier` in `VMPass_Verifier.h/cpp` to handle the new opcode.
-6. Add a runtime test case in `llvm/utils/obfuscator/obf_runtime_tests.py` that exercises the new instruction type.
-7. Update this document and the ISA tables above.
+4. Add the handler `BasicBlock` in the appropriate `buildHandlers*` group in
+   `VMPass_Handlers.cpp` (the pass implementation was split by concern:
+   `VMPass_Handlers.cpp`, `VMPass_Wrapper.cpp`, `VMPass_Dispatch.cpp`, `VMPass_Nested.cpp`,
+   `VMPass_Crypto.cpp`, `VMPass_AntiDebug.cpp`, `VMPass_Harden.cpp`; declarations stay in
+   `VMPass_Impl.h`).
+5. Update `VMPass_Verifier.h/cpp` — including the **opcode size table** — to handle the new
+   opcode. A missing size entry makes the verifier report truncation on valid bytecode.
+6. If the opcode should participate in nested virtualisation, add a `__vm_h_<op>` helper and its
+   entry in `kNestedHelperOrder` (`VMPass_Impl.h`) + factory in `VMPass_Nested.cpp`.
+7. Add a runtime test case in `utils/cases/vm.py` (+ gate in `utils/gates/vm.py`) that exercises
+   the new instruction type.
+8. Update this document and the ISA tables above.
 
 > [!NOTE]
 > The Fisher-Yates shuffle in `VMOpcodeMap::initPermuted` naturally covers the new opcode

--- a/include/llvm/Transforms/Obfuscator/ObfuscationConfig.h
+++ b/include/llvm/Transforms/Obfuscator/ObfuscationConfig.h
@@ -329,6 +329,14 @@ namespace llvm {
 		// signature for the permuted families. Off = byte-identical (identity map).
 		bool     randISA = false;
 
+		// enginePoolSize: number of distinct shared VM engines built per module
+		// (W1 "the real kill"). N>1 builds N structurally-independent engines;
+		// each virtualized function deterministically picks one by its own seed,
+		// so lifting one function's engine gives no shortcut for a function that
+		// runs a different engine. 1 = single shared engine (byte-identical to
+		// the pre-pool build). Clamped to >=1.
+		unsigned enginePoolSize = 1;
+
 		static VMPassConfig fromPassConfig(const PassConfig& PC);
 		bool validate() const;
 	};

--- a/include/llvm/Transforms/Obfuscator/ObfuscationConfig.h
+++ b/include/llvm/Transforms/Obfuscator/ObfuscationConfig.h
@@ -347,6 +347,14 @@ namespace llvm {
 		// byte-identical.
 		bool     metamorphicEngines = false;
 
+		// perFnEngine: give THIS function its own dedicated shared engine instead
+		// of hashing it into the enginePoolSize pool. Because annotations are
+		// per-function, setting it on selected (critical) functions gives them
+		// private engines while the rest share the pool (annotation-selective);
+		// setting it everywhere gives a full per-function engine build. Highest
+		// structural resilience, highest .text cost. Off = use enginePoolSize.
+		bool     perFnEngine = false;
+
 		static VMPassConfig fromPassConfig(const PassConfig& PC);
 		bool validate() const;
 	};

--- a/include/llvm/Transforms/Obfuscator/ObfuscationConfig.h
+++ b/include/llvm/Transforms/Obfuscator/ObfuscationConfig.h
@@ -337,6 +337,16 @@ namespace llvm {
 		// the pre-pool build). Clamped to >=1.
 		unsigned enginePoolSize = 1;
 
+		// metamorphicEngines: give each engine in the pool a structurally
+		// distinct handler body, not just a distinct name. Every engine's integer
+		// handler arithmetic is rewritten with semantics-preserving MBA identities
+		// chosen from a per-engine (pool-index-derived) seed, so lifting one
+		// clone's handlers yields no pattern match for another clone -- even when
+		// handlerVariants=1 and hardened=0 leave the bodies otherwise identical.
+		// Requires enginePoolSize>1 (no clones to diversify otherwise). Off =
+		// byte-identical.
+		bool     metamorphicEngines = false;
+
 		static VMPassConfig fromPassConfig(const PassConfig& PC);
 		bool validate() const;
 	};

--- a/include/llvm/Transforms/Obfuscator/VMPass_Impl.h
+++ b/include/llvm/Transforms/Obfuscator/VMPass_Impl.h
@@ -517,11 +517,13 @@ namespace llvm {
 			SuperOps(Cfg.superOps),
 			BindAntiDebug(Cfg.bindAntiDebug),
 			RandISA(Cfg.randISA),
-			// P10: the plain layer is pooled across PoolIdxIn (0..N-1); nestedVM
-			// builds pin to pool 0's nest engine (EngineId 1) so the single shared
-			// __vm_h_* helper is virtualized exactly once (nest-layer pooling is a
-			// later phase). PoolIdxIn 0 + nestedVM?1:0 reproduces the pre-pool id.
-			EngineId(VMEngine::makeEngineId(NestedVM ? 0u : PoolIdxIn, NestedVM ? 1u : 0u)),
+			// P10: both layers are pooled across PoolIdxIn (0..N-1). A plain
+			// function in pool p targets @__vm_engine[.pp]; a nestedVM function in
+			// pool p targets @__vm_engine.nest[.pp], whose eligible handlers call
+			// the single shared __vm_h_* helper set (itself virtualized once
+			// against the plain pool-0 engine -- see virtualizeNestedHelpersOnce).
+			// PoolIdxIn 0 + nestedVM?1:0 reproduces the pre-pool id (0 or 1).
+			EngineId(VMEngine::makeEngineId(PoolIdxIn, NestedVM ? 1u : 0u)),
 			EnginePoolSize(Cfg.enginePoolSize ? Cfg.enginePoolSize : 1u),
 			SaltConst(R.u32()),
 			// IMPORTANT: indices are only XOR-salted when obfRegIdx=1.

--- a/include/llvm/Transforms/Obfuscator/VMPass_Impl.h
+++ b/include/llvm/Transforms/Obfuscator/VMPass_Impl.h
@@ -346,6 +346,9 @@ namespace llvm {
 		// Number of distinct engines in the module pool (P10, Cfg.enginePoolSize
 		// clamped to >=1). 1 = single shared engine (byte-identical to pre-pool).
 		const unsigned EnginePoolSize;
+		// Give each pool engine a structurally distinct handler body via a
+		// per-clone-seeded MBA rewrite (requires EnginePoolSize>1). Off = no rewrite.
+		const bool     MetamorphicEngines;
 		const uint32_t SaltConst;    // full 32-bit salt stored in vm.salt
 		const uint8_t  CTSalt;       // low byte of SaltConst must match deobf() key
 		// Module-uniform obfuscation seed (Ann.ModuleSeed). Same value for every
@@ -525,6 +528,7 @@ namespace llvm {
 			// PoolIdxIn 0 + nestedVM?1:0 reproduces the pre-pool id (0 or 1).
 			EngineId(VMEngine::makeEngineId(PoolIdxIn, NestedVM ? 1u : 0u)),
 			EnginePoolSize(Cfg.enginePoolSize ? Cfg.enginePoolSize : 1u),
+			MetamorphicEngines(Cfg.metamorphicEngines),
 			SaltConst(R.u32()),
 			// IMPORTANT: indices are only XOR-salted when obfRegIdx=1.
 			// When obfRegIdx=0, emitter must write raw indices (CTSalt=0).
@@ -928,6 +932,7 @@ namespace llvm {
 		void flattenWrapper();        // switch-dispatch flattening
 		void hardenVMEngine(Function* EF, VMEngine::SharedState* SS);
 		void diversifyHandlerVariants(Function* EF); // per-variant MBA metamorphism
+		void metamorphRewriteEngine(Function* EF);   // per-clone MBA metamorphism (engine pool)
 
 		// anti-debug infrastructure
 		/// Emit IR to silently corrupt the salt value (salt ^= PoisonKey).

--- a/include/llvm/Transforms/Obfuscator/VMPass_Impl.h
+++ b/include/llvm/Transforms/Obfuscator/VMPass_Impl.h
@@ -483,6 +483,16 @@ namespace llvm {
 		// single-engine build keeps EngineId = NestedVM?1:0 exactly (byte-identical).
 		static unsigned computePoolIdx(const Function& Fn, const VMPassConfig& Cfg,
 			uint64_t MasterSeed) {
+			// perFnEngine: dedicate a private engine to this function via a wide
+			// per-function hash (collision probability ~ n^2 / 2^30, negligible).
+			// Bit 30 is set so these ids never overlap the small [0,enginePoolSize)
+			// pool range, letting per-function and pooled functions coexist in one
+			// module (annotation-selective use). EngineId = poolIdx*2 + layer stays
+			// within 32 bits (max poolIdx 0x7FFFFFFF -> EngineId 0xFFFFFFFF).
+			if (Cfg.perFnEngine) {
+				uint64_t H = obf::mix64(MasterSeed ^ obf::fnv1a64(Fn.getName()));
+				return (unsigned)(H & 0x3FFFFFFFu) | 0x40000000u;
+			}
 			unsigned N = Cfg.enginePoolSize ? Cfg.enginePoolSize : 1u;
 			if (N <= 1) return 0;
 			uint64_t H = obf::mix64(MasterSeed ^ obf::fnv1a64(Fn.getName()));

--- a/include/llvm/Transforms/Obfuscator/VMPass_Impl.h
+++ b/include/llvm/Transforms/Obfuscator/VMPass_Impl.h
@@ -469,14 +469,30 @@ namespace llvm {
 
 		// Normal per-function path: config + RNG come from the annotation-driven
 		// VMCtx (FunctionObfContextAnalysis-backed).
-		explicit VMImpl(VMCtx& VCtx) : VMImpl(VCtx.F, VCtx.Cfg, VCtx.R, VCtx.MasterSeed) {}
+		explicit VMImpl(VMCtx& VCtx)
+			: VMImpl(VCtx.F, VCtx.Cfg, VCtx.R, VCtx.MasterSeed,
+				computePoolIdx(VCtx.F, VCtx.Cfg, VCtx.MasterSeed)) {}
+
+		// P10: deterministically assign this function to one of Cfg.enginePoolSize
+		// plain engines. The module-uniform MasterSeed is mixed with the function
+		// name hash so the split is stable within a build yet diversifies across
+		// seeds. Returns 0 WITHOUT hashing when pooling is off (size <= 1), so a
+		// single-engine build keeps EngineId = NestedVM?1:0 exactly (byte-identical).
+		static unsigned computePoolIdx(const Function& Fn, const VMPassConfig& Cfg,
+			uint64_t MasterSeed) {
+			unsigned N = Cfg.enginePoolSize ? Cfg.enginePoolSize : 1u;
+			if (N <= 1) return 0;
+			uint64_t H = obf::mix64(MasterSeed ^ obf::fnv1a64(Fn.getName()));
+			return (unsigned)(H % N);
+		}
 
 		// Synthetic-function path: explicit config + RNG, no VMCtx/annotation.
 		// Used to virtualize compiler-authored helper functions (e.g. nested-VM
 		// opcode helpers) that have no FunctionObfContext of their own. The caller
 		// must forward the outer module's MasterSeed so RandISA's operand-encoding
 		// map is identical to the shared handler and the outer emitters.
-		VMImpl(Function& Fn, const VMPassConfig& CfgIn, obf::Rng& RIn, uint64_t MasterSeedIn = 0)
+		VMImpl(Function& Fn, const VMPassConfig& CfgIn, obf::Rng& RIn, uint64_t MasterSeedIn = 0,
+			unsigned PoolIdxIn = 0)
 			: F(Fn), M(*Fn.getParent()), Ctx(Fn.getContext()),
 			I8Ty(Type::getInt8Ty(Ctx)),
 			I16Ty(Type::getInt16Ty(Ctx)),
@@ -501,7 +517,11 @@ namespace llvm {
 			SuperOps(Cfg.superOps),
 			BindAntiDebug(Cfg.bindAntiDebug),
 			RandISA(Cfg.randISA),
-			EngineId(NestedVM ? 1u : 0u),
+			// P10: the plain layer is pooled across PoolIdxIn (0..N-1); nestedVM
+			// builds pin to pool 0's nest engine (EngineId 1) so the single shared
+			// __vm_h_* helper is virtualized exactly once (nest-layer pooling is a
+			// later phase). PoolIdxIn 0 + nestedVM?1:0 reproduces the pre-pool id.
+			EngineId(VMEngine::makeEngineId(NestedVM ? 0u : PoolIdxIn, NestedVM ? 1u : 0u)),
 			EnginePoolSize(Cfg.enginePoolSize ? Cfg.enginePoolSize : 1u),
 			SaltConst(R.u32()),
 			// IMPORTANT: indices are only XOR-salted when obfRegIdx=1.

--- a/include/llvm/Transforms/Obfuscator/VMPass_Impl.h
+++ b/include/llvm/Transforms/Obfuscator/VMPass_Impl.h
@@ -174,11 +174,26 @@ namespace llvm {
 		/// bytecode's own binops never call back into the helper.
 		static constexpr const char* kVMEngineNestName = "__vm_engine.nest";
 
+		/// P10 engine pool: EngineId packs (poolIdx, layer) as
+		/// `EngineId = poolIdx*2 + layer`, where layer 0 = plain, 1 = nest.
+		/// poolIdx 0 reproduces the pre-pool ids 0/1 exactly, so a single-engine
+		/// build (enginePoolSize==1) is byte-identical.
+		inline unsigned engineLayer(unsigned EngineId)  { return EngineId & 1u; }
+		inline unsigned enginePoolOf(unsigned EngineId) { return EngineId >> 1; }
+		inline unsigned makeEngineId(unsigned Pool, unsigned Layer) {
+			return Pool * 2u + (Layer & 1u);
+		}
+
 		/// EngineId 0 -> plain engine ("__vm_engine"), 1 -> nesting engine
-		/// ("__vm_engine.nest"). Selects both the SharedState instance and the
-		/// emitted Function's symbol name.
-		inline const char* vmEngineName(unsigned EngineId) {
-			return EngineId ? kVMEngineNestName : kVMEngineName;
+		/// ("__vm_engine.nest"); pool members >0 append ".p<N>" to the base name
+		/// ("__vm_engine.p1", "__vm_engine.nest.p1", ...). Selects both the
+		/// SharedState instance and the emitted Function's symbol name. poolIdx 0
+		/// returns the exact pre-pool names -> byte-identical single-engine build.
+		inline std::string vmEngineName(unsigned EngineId) {
+			std::string Base = engineLayer(EngineId) ? kVMEngineNestName : kVMEngineName;
+			unsigned Pool = enginePoolOf(EngineId);
+			if (Pool == 0) return Base;
+			return Base + ".p" + std::to_string(Pool);
 		}
 
 		/// Return the canonical FunctionType for vm_engine. `lazy` appends the
@@ -320,12 +335,17 @@ namespace llvm {
 		const bool     SuperOps;         // fuse eligible i32 mul+add chains into one OP_MULADD opcode at emission
 		const bool     BindAntiDebug;    // fold anti-debug detection into the AES round-key mask instead of salt-poisoning traps
 		const bool     RandISA;          // per-build permutation of semantic operand-field byte encodings (currently BinSubop)
-		// Which shared engine this build targets: 0 = plain ("__vm_engine"),
-		// 1 = nesting ("__vm_engine.nest"). Derived from NestedVM, not an
-		// independent knob -- a nestedVM=true build always wants the engine
-		// whose OP_BINOP calls the helper; nestedVM=false (including the
-		// helper's own inner-virtualization) always wants the plain one.
+		// Which shared engine this build targets. Packs (poolIdx, layer) as
+		// poolIdx*2 + layer (layer 0 = plain "__vm_engine", 1 = nesting
+		// "__vm_engine.nest"). The layer is derived from NestedVM (a nestedVM=true
+		// build wants the engine whose OP_BINOP calls the helper; nestedVM=false,
+		// including the helper's own inner-virtualization, wants the plain one).
+		// The poolIdx (P10) selects which of EnginePoolSize structurally-distinct
+		// engines this function runs; poolIdx 0 reproduces the pre-pool ids 0/1.
 		const unsigned EngineId;
+		// Number of distinct engines in the module pool (P10, Cfg.enginePoolSize
+		// clamped to >=1). 1 = single shared engine (byte-identical to pre-pool).
+		const unsigned EnginePoolSize;
 		const uint32_t SaltConst;    // full 32-bit salt stored in vm.salt
 		const uint8_t  CTSalt;       // low byte of SaltConst must match deobf() key
 		// Module-uniform obfuscation seed (Ann.ModuleSeed). Same value for every
@@ -482,6 +502,7 @@ namespace llvm {
 			BindAntiDebug(Cfg.bindAntiDebug),
 			RandISA(Cfg.randISA),
 			EngineId(NestedVM ? 1u : 0u),
+			EnginePoolSize(Cfg.enginePoolSize ? Cfg.enginePoolSize : 1u),
 			SaltConst(R.u32()),
 			// IMPORTANT: indices are only XOR-salted when obfRegIdx=1.
 			// When obfRegIdx=0, emitter must write raw indices (CTSalt=0).

--- a/utils/cases/_common.py
+++ b/utils/cases/_common.py
@@ -203,6 +203,19 @@ EXTRA_ANN: Dict[str, str] = {
     "vm_v7_randisa_stack":    "vm(minBlocks=1,obfRegIdx=1,encBytecode=1,useAES=1,"
                               "randISA=1,nestedVM=1,superOps=1,threadedDispatch=1,"
                               "keyedDispatch=1,encDispatch=1,lazyDecrypt=1,constInStream=1)",
+    # enginePoolSize=N: build N structurally-distinct shared engines per module;
+    # each virtualized function picks one by a hash of its name + module seed, so
+    # lifting one function's engine gives no shortcut for a function on another.
+    # Off (size 1) = byte-identical single engine. Composes with everything except
+    # nestedVM (which pins its functions to pool 0's nest engine for now).
+    "vm_v7_enginepool":          "vm(minBlocks=1,obfRegIdx=1,encBytecode=1,enginePoolSize=4)",
+    "vm_v7_enginepool_multi_fn": "vm(minBlocks=1,obfRegIdx=1,encBytecode=1,enginePoolSize=4)",
+    "vm_v7_enginepool_hardened": "vm(minBlocks=1,obfRegIdx=1,encBytecode=1,enginePoolSize=4,hardened=1)",
+    # Full composition proof (minus nestedVM): pool + superOps + threadedDispatch
+    # + keyedDispatch + encDispatch + lazyDecrypt + constInStream + useAES.
+    "vm_v7_enginepool_stack":    "vm(minBlocks=1,obfRegIdx=1,encBytecode=1,useAES=1,"
+                                 "enginePoolSize=4,superOps=1,threadedDispatch=1,"
+                                 "keyedDispatch=1,encDispatch=1,lazyDecrypt=1,constInStream=1)",
     # preset=<name>: config-surface shortcut resolved in VMPassConfig::fromPassConfig
     # before explicit knobs (which still override). medium == today's defaults.
     "vm_v7_preset_light":  "vm(minBlocks=1,preset=light)",
@@ -395,6 +408,10 @@ def render_vm_v7_multi_function_program(annotation: str) -> str:
 
 def render_vm_v7_multi_fn_aes_program(annotation: str) -> str:
     return programs.render("vm.multi_fn_aes", annotation=annotation)
+
+
+def render_vm_v7_enginepool_program(annotation: str) -> str:
+    return programs.render("vm.enginepool", annotation=annotation)
 
 
 def render_vm_v7_switch_dispatch_program(annotation: str) -> str:

--- a/utils/cases/_common.py
+++ b/utils/cases/_common.py
@@ -230,6 +230,14 @@ EXTRA_ANN: Dict[str, str] = {
                              "enginePoolSize=4,metamorphicEngines=1,superOps=1,"
                              "threadedDispatch=1,keyedDispatch=1,encDispatch=1,"
                              "lazyDecrypt=1,constInStream=1)",
+    # perFnEngine: every virtualized function gets its own dedicated engine.
+    "vm_v7_perfn":       "vm(minBlocks=1,obfRegIdx=1,encBytecode=1,perFnEngine=1)",
+    # Full composition (minus nestedVM): perFnEngine + metamorph + superOps +
+    # threaded + keyed + encDispatch + lazy + const + useAES.
+    "vm_v7_perfn_stack": "vm(minBlocks=1,obfRegIdx=1,encBytecode=1,useAES=1,"
+                         "perFnEngine=1,metamorphicEngines=1,superOps=1,"
+                         "threadedDispatch=1,keyedDispatch=1,encDispatch=1,"
+                         "lazyDecrypt=1,constInStream=1)",
     # preset=<name>: config-surface shortcut resolved in VMPassConfig::fromPassConfig
     # before explicit knobs (which still override). medium == today's defaults.
     "vm_v7_preset_light":  "vm(minBlocks=1,preset=light)",

--- a/utils/cases/_common.py
+++ b/utils/cases/_common.py
@@ -216,6 +216,9 @@ EXTRA_ANN: Dict[str, str] = {
     "vm_v7_enginepool_stack":    "vm(minBlocks=1,obfRegIdx=1,encBytecode=1,useAES=1,"
                                  "enginePoolSize=4,superOps=1,threadedDispatch=1,"
                                  "keyedDispatch=1,encDispatch=1,lazyDecrypt=1,constInStream=1)",
+    # nestedVM + pool: the nest layer is pooled too (@__vm_engine.nest.pN); the
+    # one shared __vm_h_* helper set stays virtualized exactly once (plain pool 0).
+    "vm_v7_enginepool_nested":   "vm(minBlocks=1,obfRegIdx=1,encBytecode=1,nestedVM=1,enginePoolSize=4)",
     # preset=<name>: config-surface shortcut resolved in VMPassConfig::fromPassConfig
     # before explicit knobs (which still override). medium == today's defaults.
     "vm_v7_preset_light":  "vm(minBlocks=1,preset=light)",

--- a/utils/cases/_common.py
+++ b/utils/cases/_common.py
@@ -219,6 +219,17 @@ EXTRA_ANN: Dict[str, str] = {
     # nestedVM + pool: the nest layer is pooled too (@__vm_engine.nest.pN); the
     # one shared __vm_h_* helper set stays virtualized exactly once (plain pool 0).
     "vm_v7_enginepool_nested":   "vm(minBlocks=1,obfRegIdx=1,encBytecode=1,nestedVM=1,enginePoolSize=4)",
+    # metamorphicEngines: per-clone MBA rewrite gives each pool engine a distinct
+    # handler body. handlerVariants=1 (+ no hardening) isolates the effect --
+    # without it the pool engines would be near-identical bodies.
+    "vm_v7_metamorph":       "vm(minBlocks=1,obfRegIdx=1,encBytecode=1,enginePoolSize=4,"
+                             "handlerVariants=1,metamorphicEngines=1)",
+    # Full composition (minus nestedVM): metamorph + pool + superOps + threaded +
+    # keyed + encDispatch + lazy + const + useAES.
+    "vm_v7_metamorph_stack": "vm(minBlocks=1,obfRegIdx=1,encBytecode=1,useAES=1,"
+                             "enginePoolSize=4,metamorphicEngines=1,superOps=1,"
+                             "threadedDispatch=1,keyedDispatch=1,encDispatch=1,"
+                             "lazyDecrypt=1,constInStream=1)",
     # preset=<name>: config-surface shortcut resolved in VMPassConfig::fromPassConfig
     # before explicit knobs (which still override). medium == today's defaults.
     "vm_v7_preset_light":  "vm(minBlocks=1,preset=light)",

--- a/utils/cases/vm.py
+++ b/utils/cases/vm.py
@@ -963,6 +963,18 @@ def register(reg: Registry, **_opts) -> None:
             ann_override=vm_v7_ep_multi,
             extra_opts=_DBG, gates=["seed_determinism"], category="vm",
             src_override=render_vm_v7_enginepool_program(vm_v7_ep_multi))
+    # nestedVM + pool: the nest layer is pooled too (@__vm_engine.nest.pN), while
+    # the single shared __vm_h_* helper set is still virtualized exactly once
+    # against the plain pool-0 engine. Gate hygiene: pool 0's nest slot may be
+    # empty under the hash split, so drop vm_nestedvm_dual_engine (it needs the
+    # base @__vm_engine.nest name) and keep only vm_nestedvm_helper_virtualized,
+    # whose helper always targets the plain pool-0 engine.
+    vm_v7_ep_nested = ann_extra("vm_v7_enginepool_nested")
+    reg.add(name="rt_vm_v7_enginepool_nested", passes=["vm"],
+            ann_override=vm_v7_ep_nested,
+            gates=_EP_CORE + ["vm_nestedvm_helper_virtualized"],
+            extra_opts=_DBG, category="vm",
+            src_override=render_vm_v7_enginepool_program(vm_v7_ep_nested))
 
     # ── preset=<light|medium|high|max> config-surface shortcut ──
     # Resolved in VMPassConfig::fromPassConfig before the explicit-knob getBool/

--- a/utils/cases/vm.py
+++ b/utils/cases/vm.py
@@ -128,6 +128,11 @@ VM_RANDISA_GATES = ["vm_randisa_permuted", "vm_randisa_icmp_permuted",
 # two distinct engines are effectively certain across seeds).
 VM_ENGINEPOOL_GATES = ["vm_enginepool_multi"]
 
+# metamorphicEngines gives each pool engine a per-clone-seeded MBA rewrite
+# (marker `me.noise`), so the N engines have structurally distinct bodies rather
+# than name-only clones. Pairs with VM_ENGINEPOOL_GATES (>=2 engines exist).
+VM_METAMORPH_GATES = ["vm_metamorph_engines"]
+
 _DBG = ["--obf-debug", "--obf-verbose"]
 
 
@@ -138,7 +143,7 @@ def register(reg: Registry, **_opts) -> None:
             ann_override=vm_v7,
             gates=VM_CORE_GATES + ["vm_enc_ctor", "vm_no_threaded_dispatch",
                    "vm_no_keyeddisp", "vm_no_bindadeb_ctor", "vm_no_randisa",
-                   "vm_no_enginepool"],
+                   "vm_no_enginepool", "vm_no_metamorph_engines"],
             extra_opts=_DBG, category="vm")
     reg.add(name="rt_vm_v7_bare", passes=["vm"],
             ann_override=ann_extra("vm_v7_bare"),
@@ -975,6 +980,32 @@ def register(reg: Registry, **_opts) -> None:
             gates=_EP_CORE + ["vm_nestedvm_helper_virtualized"],
             extra_opts=_DBG, category="vm",
             src_override=render_vm_v7_enginepool_program(vm_v7_ep_nested))
+
+    # ── metamorphic engine pool (per-clone MBA rewrite) ──
+    # metamorphicEngines with handlerVariants=1 and no hardening isolates the
+    # feature: without it the pool engines are near-identical bodies (name-only
+    # clones); with it each engine's integer handler arithmetic is rewritten with
+    # a per-clone-seeded MBA identity (the `me.noise` marker), so the bodies
+    # diverge structurally. Same name-agnostic gate hygiene as the pool cases.
+    vm_v7_mm = ann_extra("vm_v7_metamorph")
+    vm_v7_mm_stack = ann_extra("vm_v7_metamorph_stack")
+    reg.add(name="rt_vm_v7_metamorph_multi_fn", passes=["vm"],
+            ann_override=vm_v7_mm,
+            gates=_EP_CORE + VM_METAMORPH_GATES,
+            extra_opts=_DBG, category="vm",
+            src_override=render_vm_v7_enginepool_program(vm_v7_mm))
+    # Full-stack composition (minus nestedVM): threaded build drops the central
+    # vm.dispatch, so use VM_THREADED_CORE_GATES.
+    reg.add(name="rt_vm_v7_metamorph_stack", passes=["vm"],
+            ann_override=vm_v7_mm_stack,
+            gates=VM_THREADED_CORE_GATES + VM_ENGINEPOOL_GATES + VM_METAMORPH_GATES
+                + ["vm_enc_ctor", "vm_wrapper_is_thin"],
+            extra_opts=_DBG, category="vm",
+            src_override=render_vm_v7_enginepool_program(vm_v7_mm_stack))
+    reg.add(name="rt_vm_v7_metamorph_determinism", passes=["vm"],
+            ann_override=vm_v7_mm,
+            extra_opts=_DBG, gates=["seed_determinism"], category="vm",
+            src_override=render_vm_v7_enginepool_program(vm_v7_mm))
 
     # ── preset=<light|medium|high|max> config-surface shortcut ──
     # Resolved in VMPassConfig::fromPassConfig before the explicit-knob getBool/

--- a/utils/cases/vm.py
+++ b/utils/cases/vm.py
@@ -1065,10 +1065,20 @@ def register(reg: Registry, **_opts) -> None:
             gates=VM_THREADED_SHARED_GATES + VM_THREADED_GATES,
             extra_opts=_DBG, category="vm",
             src_override=render_vm_v7_multi_fn_aes_program(vm_v7_preset_high))
+    # preset=max now also sets perFnEngine + metamorphicEngines, so the build
+    # holds many distinct engines (one dedicated engine per function, each with a
+    # per-clone-diversified body) instead of a single shared one. Drop the
+    # singleton engine gate and nestedVM's dual-engine gate (which hard-code the
+    # single base @__vm_engine[.nest] names that no longer describe a per-function
+    # pooled build) and add the pool / per-function / metamorphic feature gates.
+    _MAX_ENGINE_GATES = [g for g in VM_THREADED_ENGINE_GATES if g != "vm_engine_singleton"]
     reg.add(name="rt_vm_v7_preset_max_multi_fn", passes=["vm"],
             ann_override=vm_v7_preset_max,
-            gates=VM_THREADED_SHARED_GATES + VM_LAZYDECRYPT_GATES + VM_CONSTINSTREAM_GATES
-                + VM_NESTEDVM_GATES + VM_SUPEROPS_GATES + VM_KEYEDDISP_GATES
+            gates=VM_THREADED_CORE_GATES + _MAX_ENGINE_GATES
+                + VM_ENGINEPOOL_GATES + VM_METAMORPH_GATES + ["vm_perfn_engine"]
+                + VM_LAZYDECRYPT_GATES + VM_CONSTINSTREAM_GATES
+                + ["vm_nestedvm_helper_virtualized"]
+                + VM_SUPEROPS_GATES + VM_KEYEDDISP_GATES
                 + VM_BINDADEB_GATES + VM_THREADED_GATES,
             extra_opts=_DBG, category="vm",
             src_override=render_vm_v7_multi_fn_aes_program(vm_v7_preset_max))

--- a/utils/cases/vm.py
+++ b/utils/cases/vm.py
@@ -9,6 +9,7 @@ from ._common import (
     render_vm_v7_call_program,
     render_vm_v7_call_vararg_program,
     render_vm_v7_casts_program,
+    render_vm_v7_enginepool_program,
     render_vm_v7_float_basic_program,
     render_vm_v7_float_cast_program,
     render_vm_v7_float_comprehensive_program,
@@ -121,6 +122,12 @@ VM_RANDISA_GATES = ["vm_randisa_permuted", "vm_randisa_icmp_permuted",
                     "vm_randisa_cast_permuted", "vm_randisa_fbinsubop_permuted",
                     "vm_randisa_fcmp_permuted"]
 
+# enginePoolSize>1 builds several distinct shared engines (@__vm_engine[.pN]);
+# this proves more than one materialised. Attached to the multi-function pool
+# cases (the enginepool.c program has nine virtualized functions, so at least
+# two distinct engines are effectively certain across seeds).
+VM_ENGINEPOOL_GATES = ["vm_enginepool_multi"]
+
 _DBG = ["--obf-debug", "--obf-verbose"]
 
 
@@ -130,7 +137,8 @@ def register(reg: Registry, **_opts) -> None:
     reg.add(name="rt_vm_v7_basic", passes=["vm"],
             ann_override=vm_v7,
             gates=VM_CORE_GATES + ["vm_enc_ctor", "vm_no_threaded_dispatch",
-                   "vm_no_keyeddisp", "vm_no_bindadeb_ctor", "vm_no_randisa"],
+                   "vm_no_keyeddisp", "vm_no_bindadeb_ctor", "vm_no_randisa",
+                   "vm_no_enginepool"],
             extra_opts=_DBG, category="vm")
     reg.add(name="rt_vm_v7_bare", passes=["vm"],
             ann_override=ann_extra("vm_v7_bare"),
@@ -910,6 +918,51 @@ def register(reg: Registry, **_opts) -> None:
             ann_override=vm_v7_ri,
             extra_opts=_DBG, gates=["seed_determinism"], category="vm",
             src_override=render_vm_v7_multi_function_program(vm_v7_ri))
+
+    # ── P10 engine pool (enginePoolSize>1) ──
+    # Each of the enginepool.c program's nine virtualized functions is assigned
+    # to one of N=4 shared engines by a hash of its name + module seed, so the
+    # build materialises several distinct @__vm_engine[.pN] functions. The pool
+    # gate proves >=2 exist; the differential-output check (run for every case)
+    # proves the per-function split still computes correctly across engines.
+    #
+    # Gate hygiene: with a hash split any given pool slot -- including slot 0's
+    # base name @__vm_engine -- may be empty, so these cases use only NAME-
+    # AGNOSTIC gates. The singleton / multi-fn-shared / engine-body gates
+    # (which hard-code the @__vm_engine base name and assert exactly one engine)
+    # are intentionally excluded; they are proven on the non-pooled cases.
+    vm_v7_ep_multi = ann_extra("vm_v7_enginepool_multi_fn")
+    vm_v7_ep_hard = ann_extra("vm_v7_enginepool_hardened")
+    vm_v7_ep_stack = ann_extra("vm_v7_enginepool_stack")
+
+    _EP_CORE = VM_CORE_GATES + VM_ENGINEPOOL_GATES + ["vm_enc_ctor", "vm_wrapper_is_thin"]
+    reg.add(name="rt_vm_v7_enginepool_multi_fn", passes=["vm"],
+            ann_override=vm_v7_ep_multi,
+            gates=_EP_CORE,
+            extra_opts=_DBG, category="vm",
+            src_override=render_vm_v7_enginepool_program(vm_v7_ep_multi))
+    # hardened composes: MBA/dead-blocks/guards run inside whichever pool engine
+    # each function landed on. Correctness (differential output) exercises the
+    # hardened path; the hardened-internal engine-body gates are omitted because
+    # they hard-code the base engine name (see gate-hygiene note above).
+    reg.add(name="rt_vm_v7_enginepool_hardened", passes=["vm"],
+            ann_override=vm_v7_ep_hard,
+            gates=_EP_CORE,
+            extra_opts=_DBG, category="vm",
+            src_override=render_vm_v7_enginepool_program(vm_v7_ep_hard))
+    # Full-stack composition (minus nestedVM): pool + superOps + threadedDispatch
+    # + keyedDispatch + encDispatch + lazyDecrypt + constInStream + useAES. The
+    # threaded build removes the central vm.dispatch, so drop vm_dispatch_present.
+    reg.add(name="rt_vm_v7_enginepool_stack", passes=["vm"],
+            ann_override=vm_v7_ep_stack,
+            gates=VM_THREADED_CORE_GATES + VM_ENGINEPOOL_GATES
+                + ["vm_enc_ctor", "vm_wrapper_is_thin"],
+            extra_opts=_DBG, category="vm",
+            src_override=render_vm_v7_enginepool_program(vm_v7_ep_stack))
+    reg.add(name="rt_vm_v7_enginepool_determinism", passes=["vm"],
+            ann_override=vm_v7_ep_multi,
+            extra_opts=_DBG, gates=["seed_determinism"], category="vm",
+            src_override=render_vm_v7_enginepool_program(vm_v7_ep_multi))
 
     # ── preset=<light|medium|high|max> config-surface shortcut ──
     # Resolved in VMPassConfig::fromPassConfig before the explicit-knob getBool/

--- a/utils/cases/vm.py
+++ b/utils/cases/vm.py
@@ -1007,6 +1007,31 @@ def register(reg: Registry, **_opts) -> None:
             extra_opts=_DBG, gates=["seed_determinism"], category="vm",
             src_override=render_vm_v7_enginepool_program(vm_v7_mm))
 
+    # ── per-function engine (perFnEngine, annotation-selective P10-B/C) ──
+    # Every virtualized function gets its own dedicated engine; vm_perfn_engine
+    # asserts >= one distinct engine per function's handler table. Name-agnostic
+    # gate hygiene as with the pool cases (base @__vm_engine is never emitted --
+    # per-function ids all carry a .pN suffix).
+    vm_v7_pf = ann_extra("vm_v7_perfn")
+    vm_v7_pf_stack = ann_extra("vm_v7_perfn_stack")
+    reg.add(name="rt_vm_v7_perfn_multi_fn", passes=["vm"],
+            ann_override=vm_v7_pf,
+            gates=_EP_CORE + ["vm_perfn_engine"],
+            extra_opts=_DBG, category="vm",
+            src_override=render_vm_v7_enginepool_program(vm_v7_pf))
+    # Full-stack composition (minus nestedVM): perFnEngine + metamorph + the rest.
+    # Threaded build drops the central vm.dispatch, so use VM_THREADED_CORE_GATES.
+    reg.add(name="rt_vm_v7_perfn_stack", passes=["vm"],
+            ann_override=vm_v7_pf_stack,
+            gates=VM_THREADED_CORE_GATES + VM_ENGINEPOOL_GATES + VM_METAMORPH_GATES
+                + ["vm_perfn_engine", "vm_enc_ctor", "vm_wrapper_is_thin"],
+            extra_opts=_DBG, category="vm",
+            src_override=render_vm_v7_enginepool_program(vm_v7_pf_stack))
+    reg.add(name="rt_vm_v7_perfn_determinism", passes=["vm"],
+            ann_override=vm_v7_pf,
+            extra_opts=_DBG, gates=["seed_determinism"], category="vm",
+            src_override=render_vm_v7_enginepool_program(vm_v7_pf))
+
     # ── preset=<light|medium|high|max> config-surface shortcut ──
     # Resolved in VMPassConfig::fromPassConfig before the explicit-knob getBool/
     # getUInt calls, so this is a pure config-resolution convenience, not a new

--- a/utils/gates/vm.py
+++ b/utils/gates/vm.py
@@ -556,3 +556,25 @@ def vm_no_enginepool(ir: str) -> Optional[str]:
     if pool:
         return f"found {len(pool)} pool-member engine(s) but enginePoolSize=1 — pool leaked when off"
     return None
+
+
+@register("vm_metamorph_engines")
+def vm_metamorph_engines(ir: str) -> Optional[str]:
+    # metamorphicEngines rewrites each pool clone's integer handler arithmetic
+    # with per-clone-seeded MBA identities (metamorphRewriteEngine), tagging the
+    # result `me.noise`. The marker is emitted nowhere else, so its presence
+    # proves the per-clone rewrite fired. The seed is keyed on EngineId, so any
+    # two engines that both carry it necessarily diverge (different identity
+    # picks); the companion vm_enginepool_multi gate proves >=2 engines exist,
+    # and the differential-output gate proves the rewrite stayed correct.
+    if not re.search(r"me\.noise", ir):
+        return "no me.noise marker — per-clone metamorphic engine rewrite did not run"
+    return None
+
+
+@register("vm_no_metamorph_engines")
+def vm_no_metamorph_engines(ir: str) -> Optional[str]:
+    n = len(re.findall(r"me\.noise", ir))
+    if n:
+        return f"found {n} me.noise marker(s) but metamorphicEngines=0 — leaked when off"
+    return None

--- a/utils/gates/vm.py
+++ b/utils/gates/vm.py
@@ -523,3 +523,37 @@ def vm_randisa_fcmp_permuted(ir: str) -> Optional[str]:
     if all(_RANDISA_FCMP_CANON.get(k) == v for k, v in m.items()):
         return f"OP_FCMP predicate encoding is canonical ({sorted(m.items())}) — randISA not applied"
     return None
+
+
+# ── P10 engine pool ──────────────────────────────────────────────────────────
+# The plain shared engine is emitted as @__vm_engine; with enginePoolSize>1 the
+# pass builds additional pool members @__vm_engine.p1, @__vm_engine.p2, ... and
+# each virtualized function's handler table targets whichever one its name+seed
+# hash selected. (Nested-VM builds an orthogonal @__vm_engine.nest[.pN]; the
+# regexes below deliberately match only the plain-layer names.)
+def _plain_engine_defs(ir: str) -> set:
+    return set(re.findall(r"^define\b[^\n]*@(__vm_engine(?:\.p\d+)?)\(", ir, re.M))
+
+
+@register("vm_enginepool_multi")
+def vm_enginepool_multi(ir: str) -> Optional[str]:
+    # enginePoolSize>1: prove the module actually contains more than one distinct
+    # shared engine (not a silent single-engine no-op). Any two-plus distinct
+    # plain-engine definitions satisfy it; the exact per-function split is a hash
+    # of the name + module seed and is asserted correct by the differential-output
+    # gates, not here.
+    defs = _plain_engine_defs(ir)
+    if len(defs) < 2:
+        return (f"expected >=2 distinct plain engines, found {sorted(defs)} — "
+                "engine pool did not materialise multiple engines")
+    return None
+
+
+@register("vm_no_enginepool")
+def vm_no_enginepool(ir: str) -> Optional[str]:
+    # Inverse: with pooling off (enginePoolSize=1, the default) the module has
+    # exactly one plain engine @__vm_engine and no .pN pool members.
+    pool = re.findall(r"^define\b[^\n]*@__vm_engine\.p\d+\(", ir, re.M)
+    if pool:
+        return f"found {len(pool)} pool-member engine(s) but enginePoolSize=1 — pool leaked when off"
+    return None

--- a/utils/gates/vm.py
+++ b/utils/gates/vm.py
@@ -578,3 +578,19 @@ def vm_no_metamorph_engines(ir: str) -> Optional[str]:
     if n:
         return f"found {n} me.noise marker(s) but metamorphicEngines=0 — leaked when off"
     return None
+
+
+@register("vm_perfn_engine")
+def vm_perfn_engine(ir: str) -> Optional[str]:
+    # perFnEngine gives every virtualized function its own dedicated engine, so
+    # the number of distinct @__vm_engine* definitions is at least the number of
+    # per-function handler tables (@<fn>.vm.ophandlers, excluding the shared
+    # __vm_h_* nested helpers). A pooled build has far fewer engines than
+    # functions, so this only holds under perFnEngine.
+    engines = set(re.findall(r"^define\b[^\n]*@(__vm_engine(?:\.nest)?(?:\.p\d+)?)\(", ir, re.M))
+    tables = set(re.findall(r"@(\w+)\.vm\.ophandlers\b", ir))
+    userfns = {t for t in tables if not t.startswith("__vm_h_")}
+    if len(engines) < len(userfns):
+        return (f"{len(engines)} distinct engines for {len(userfns)} virtualized "
+                "functions — not a per-function engine build")
+    return None

--- a/utils/gates/vm.py
+++ b/utils/gates/vm.py
@@ -526,34 +526,33 @@ def vm_randisa_fcmp_permuted(ir: str) -> Optional[str]:
 
 
 # ── P10 engine pool ──────────────────────────────────────────────────────────
-# The plain shared engine is emitted as @__vm_engine; with enginePoolSize>1 the
-# pass builds additional pool members @__vm_engine.p1, @__vm_engine.p2, ... and
-# each virtualized function's handler table targets whichever one its name+seed
-# hash selected. (Nested-VM builds an orthogonal @__vm_engine.nest[.pN]; the
-# regexes below deliberately match only the plain-layer names.)
-def _plain_engine_defs(ir: str) -> set:
-    return set(re.findall(r"^define\b[^\n]*@(__vm_engine(?:\.p\d+)?)\(", ir, re.M))
+# The shared engine is @__vm_engine (plain) or @__vm_engine.nest (nestedVM's
+# inner layer). With enginePoolSize>1 the pass emits additional pool members by
+# appending .p<N> to either layer -- @__vm_engine.p1, @__vm_engine.nest.p2, ...
+# -- and each virtualized function's handler table targets whichever engine its
+# name+seed hash selected. A .pN suffix is emitted ONLY when pooling is active
+# and some function hashed to pool>=1, so its presence is unambiguous proof of
+# pooling (distinct from the plain/nest split nestedVM produces on its own).
+_POOL_MEMBER_RE = r"^define\b[^\n]*@__vm_engine(?:\.nest)?\.p\d+\("
 
 
 @register("vm_enginepool_multi")
 def vm_enginepool_multi(ir: str) -> Optional[str]:
-    # enginePoolSize>1: prove the module actually contains more than one distinct
-    # shared engine (not a silent single-engine no-op). Any two-plus distinct
-    # plain-engine definitions satisfy it; the exact per-function split is a hash
-    # of the name + module seed and is asserted correct by the differential-output
-    # gates, not here.
-    defs = _plain_engine_defs(ir)
-    if len(defs) < 2:
-        return (f"expected >=2 distinct plain engines, found {sorted(defs)} — "
-                "engine pool did not materialise multiple engines")
+    # enginePoolSize>1: prove the pool actually materialised by finding at least
+    # one .pN pool-member engine (on either the plain or the nest layer). The
+    # exact per-function split is a hash of the name + module seed and is asserted
+    # correct by the differential-output gate, not here.
+    if not re.search(_POOL_MEMBER_RE, ir, re.M):
+        return ("no .pN pool-member engine found — engine pool did not "
+                "materialise multiple engines")
     return None
 
 
 @register("vm_no_enginepool")
 def vm_no_enginepool(ir: str) -> Optional[str]:
-    # Inverse: with pooling off (enginePoolSize=1, the default) the module has
-    # exactly one plain engine @__vm_engine and no .pN pool members.
-    pool = re.findall(r"^define\b[^\n]*@__vm_engine\.p\d+\(", ir, re.M)
+    # Inverse: with pooling off (enginePoolSize=1, the default) no .pN pool
+    # members exist on either layer.
+    pool = re.findall(_POOL_MEMBER_RE, ir, re.M)
     if pool:
         return f"found {len(pool)} pool-member engine(s) but enginePoolSize=1 — pool leaked when off"
     return None

--- a/utils/programs/vm/enginepool.c.tmpl
+++ b/utils/programs/vm/enginepool.c.tmpl
@@ -1,0 +1,81 @@
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+/* Nine independently-virtualized functions. With enginePoolSize>1 the pass
+   assigns each to one of N shared engines by a hash of its name + the module
+   seed, so a build ends up with several distinct @__vm_engine[.pN] functions.
+   Nine functions make "at least two distinct engines" statistically certain
+   across seeds (P(all in one pool) at N=4 is ~6e-5). */
+
+__attribute__((noinline, annotate("{annotation}")))
+uint32_t obf_ep0(uint32_t x, uint32_t y) {{
+    uint32_t r = x + y;
+    for (uint32_t i = 0; i < (y & 7u); i++) r = r * 3u + i;
+    return r ^ 0x9E3779B9u;
+}}
+
+__attribute__((noinline, annotate("{annotation}")))
+uint32_t obf_ep1(uint32_t x, uint32_t y) {{
+    uint32_t s = x;
+    if (y & 1u) s = s * 7u + 11u; else s = s - y;
+    return s ^ (x << 3);
+}}
+
+__attribute__((noinline, annotate("{annotation}")))
+uint32_t obf_ep2(uint32_t a, uint32_t b) {{
+    uint32_t t = a ^ b;
+    for (uint32_t i = 0; i < (a & 3u); i++) t += (b >> (i & 7u)) + 1u;
+    return t + 0x1234u;
+}}
+
+__attribute__((noinline, annotate("{annotation}")))
+uint32_t obf_ep3(uint32_t a, uint32_t b) {{
+    uint32_t u = a * b;
+    if (u > 4096u) u -= 999u; else u += 17u;
+    return u ^ (a >> 2);
+}}
+
+__attribute__((noinline, annotate("{annotation}")))
+uint32_t obf_ep4(uint32_t x, uint32_t y) {{
+    uint32_t r = 1u;
+    for (uint32_t i = 1; i <= (x & 0xFu); i++) r = r * i + y;
+    return r - x;
+}}
+
+__attribute__((noinline, annotate("{annotation}")))
+uint32_t obf_ep5(uint32_t x, uint32_t y) {{
+    uint32_t s = (x << 1) + (y >> 1);
+    s = (s & 0xFFFFu) | ((x ^ y) << 16);
+    return s + 3u;
+}}
+
+__attribute__((noinline, annotate("{annotation}")))
+uint32_t obf_ep6(uint32_t a, uint32_t b) {{
+    uint32_t v = a;
+    while (v > b && v > 1u) v = v - b - 1u;
+    return v ^ (b + 7u);
+}}
+
+__attribute__((noinline, annotate("{annotation}")))
+uint32_t obf_ep7(uint32_t a, uint32_t b) {{
+    uint32_t w = a + 2u * b;
+    for (uint32_t i = 0; i < 4u; i++) w = (w * 5u + 1u) ^ (a >> i);
+    return w;
+}}
+
+__attribute__((noinline, annotate("{annotation}")))
+uint32_t obf_target(uint32_t x, uint32_t y) {{
+    uint32_t a = obf_ep0(x, y) + obf_ep1(y, x);
+    a += obf_ep2(x, y) ^ obf_ep3(y, x);
+    a += obf_ep4(x, y) + obf_ep5(y, x);
+    a += obf_ep6(x, y) ^ obf_ep7(y, x);
+    return a;
+}}
+
+int main(int argc, char** argv) {{
+    uint32_t x = (argc > 1) ? (uint32_t)atoi(argv[1]) : 42;
+    uint32_t y = (argc > 2) ? (uint32_t)atoi(argv[2]) : 17;
+    printf("%u\n", obf_target(x, y));
+    return 0;
+}}


### PR DESCRIPTION
## Summary

Round 3 of VM hardening:  that raises the
per-lift *multiplier* rather than just the per-lift *cost*. A build can now spread virtualised
functions across many structurally-distinct interpreter engines, give a function its own
private engine, and diversify every engine's handler bodies — so lifting one function's engine
yields no shortcut for a function that runs a different one.

Every feature is behind its own knob, **default OFF and byte-identical when off**. `preset=max`
opts the whole set in. Full VM runtime suite green at every step.

## What's new

| Knob | What it does |
|---|---|
| `enginePoolSize=N` | Build N structurally-distinct engines per module; assign each function to one by a name+seed hash (`__vm_engine`, `__vm_engine.p1`, …). |
| `perFnEngine=1` | Give *this* function its own dedicated engine (wide per-function hash id). Annotation-selective — set it on the critical functions only, or everywhere for a full per-function build. |
| `metamorphicEngines=1` | Rewrite each engine's integer handler arithmetic with a per-clone-seeded MBA identity, so pool engines have structurally **distinct bodies**, not just distinct names — even at `handlerVariants=1, hardened=0`. |
| `preset=max` | Now also enables `perFnEngine` + `metamorphicEngines` on top of the existing full stack. |

Under `nestedVM` the pooling extends to the nested layer too (`__vm_engine.nest.pN`), while the
shared `__vm_h_*` helper set stays virtualised exactly once against the plain pool-0 engine.

## Design notes

- **EngineId now packs `(poolIdx, layer)`** as `poolIdx*2 + layer`. `poolIdx 0` reproduces the
  pre-pool ids `0/1` and their exact symbol names, so a single-engine build is byte-identical.
  The whole build chain (`getSharedState` → populate → handler table → wrapper) already keyed on
  `(Module*, EngineId)` from the P6 two-engine work, so pooling was a localised extension.
- **Per-clone metamorphism** reuses the proven `diversifyHandlerVariants` MBA machinery over the
  same `VariantOf` handler blocks, seeded from `MasterSeed ^ EngineId` (module-uniform, keyed on
  the clone — independent of which function founded the engine). Runs right after variant
  diversification, so the dispatch `urem`/IP arithmetic a lifter fingerprints is untouched.
- **Nested-helper guard** re-keyed onto the plain pool-0 shared state so N nest engines share one
  guard and the helpers are virtualised exactly once (verified: 7 helpers, 7 definitions).
- **Risk register retired empirically** — CALL-switch per engine (K-1 pin), the FunctionType
  registry, and constructor-priority collisions all pass under pooling (the test program drives
  cross-function calls across pooled engines plus per-engine AES/integrity/anti-debug ctors).

## Commits

- `664e41e` add engine-pool knob and pool-packed engine ids
- `faa1eaf` assign functions across a pool of shared engines
- `f4d9702` pool the nested-VM engine layer
- `83569b2` give each pooled engine a distinct handler body (metamorphic)
- `b01db77` dedicate a private engine to selected functions (perFnEngine)
- `41ffd94` enable per-function metamorphic engines in preset=max
- `2b7a7b0` docs(vm): document round-2 and round-3 virtualisation features

## Testing

Every increment was proven by construction (byte-identical off), by scratchpad round-trip on
multiple shapes and seeds, and by the runtime suite:

- New 9-function `enginepool.c` program (makes ≥2 distinct engines statistically certain);
  gates `vm_enginepool_multi`, `vm_metamorph_engines`, `vm_perfn_engine`, plus inverted
  off-gates on `rt_vm_v7_basic`.
- Cases: `rt_vm_v7_{enginepool,metamorph,perfn}_{multi_fn,stack,determinism}` (+ nested),
  and `preset_max` retargeted to the pooled, name-agnostic gate shape.
- Empirical firing: metamorph raises normalised handler-body divergence from ~0.5% to ~24% at
  `handlerVariants=1, hardened=0`; `perFnEngine` yields one distinct engine per function;
  `preset=max` builds a plain helper engine + one dedicated nest engine per function.
- **Full `run_regression.ps1 -- --category vm --seeds 1,2,3` = 125/125 PASS** at the final commit.

## Docs

`docs/VM.md` brought current since the last docs release: `OP_COUNT 0x33→0x35`
(`OP_LOADI64`, `OP_MULADD`), AES-only bytecode encryption (LCG/`useAES` removed) with
`lazyDecrypt` + `constInStream`, the RDTSC debounce and `bindAntiDebug` anti-debug additions,
a new *Structural virtualisation features* section (nestedVM, threaded/keyed dispatch, superOps,
randISA, engine pool), a rewritten configuration reference with the `preset` bundles, and
refreshed IR-construction phases / split-source map.

## Compatibility

All new knobs default OFF and are byte-identical when off (the only non-byte diff at
`enginePoolSize=1` is the echoed annotation-string constant). No default behaviour changes
except `preset=max`, which opts into the new tier by design.
