### PR TITLE
feat: add -enable-obfuscation EP hook for in-compiler obfuscation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -218,6 +218,18 @@ jobs:
           echo "secret: $before -> $after"
           [ "$after" -gt "$before" ] || { echo "obfuscation did not transform"; exit 1; }
           "$OPT" -passes=verify ann_obf.ll -disable-output
+          # --- EP hook: obfuscation runs inside a normal clang compile ---
+          "$CLANG" -O2 -mllvm -enable-obfuscation -emit-llvm -S ann.c -o ann_ep.ll
+          ep=$(awk '/define .*@secret\(/,/^}/' ann_ep.ll | wc -l)
+          echo "secret (EP): $before -> $ep"
+          [ "$ep" -gt "$before" ] || { echo "EP hook did not obfuscate"; exit 1; }
+          "$OPT" -passes=verify ann_ep.ll -disable-output
+          # EP flag on un-annotated code must be a no-op (still valid IR)
+          cat > plain.c <<'EOF'
+          int plain(int x){ return x + 1; }
+          EOF
+          "$CLANG" -O2 -mllvm -enable-obfuscation -emit-llvm -S plain.c -o plain_ep.ll
+          "$OPT" -passes=verify plain_ep.ll -disable-output
 
       # ---------- Package ----------
       - name: Package (Linux)

--- a/docs/USER.md
+++ b/docs/USER.md
@@ -153,19 +153,38 @@ opt -passes=obfuscation -S test.ll -o test.obf.ll \
 clang test.obf.ll -O2 -o test.obf
 ```
 
-### Using clang
+### Using clang (in-compiler, no opt round-trip)
 
-Because this is **in-tree**, you can pass the pipeline directly to clang via `-mllvm`:
+The obfuscator can run inside a normal clang compile via an extension point,
+gated by the default-off `-enable-obfuscation` flag. This works with both the
+`clang` and `clang-cl` drivers, so it drops into existing build systems
+(MSBuild/Visual Studio, CMake, Make) that call clang per translation unit.
 
 ```bash
+# clang driver
 clang test.c -O2 \
-  -mllvm -passes=obfuscation \
+  -mllvm -enable-obfuscation \
   -mllvm -obf-seed=1 \
   -mllvm -obf-deterministic \
   -o test.obf
 ```
 
-If your toolchain does not forward `-passes` reliably through `-mllvm`, use the `opt` flow instead.
+```powershell
+# clang-cl driver (MSVC-style; forward LLVM flags with /clang:)
+clang-cl /O2 /c test.cpp `
+  /clang:-mllvm /clang:-enable-obfuscation `
+  /clang:-mllvm /clang:-obf-seed=1 `
+  /clang:-mllvm /clang:-obf-deterministic `
+  /Fotest.obj
+```
+
+Only functions carrying an `obf:` annotation are transformed; without
+annotations the flag is a no-op. Do not combine this with a separate
+`opt -passes=obfuscation` step on the same IR (it would run twice).
+
+**Visual Studio / MSBuild:** set the project's compiler to xollvm's `clang-cl`
+(LLVM toolset), then add the `/clang:-mllvm /clang:-enable-obfuscation` options
+(plus any seed flags) to C/C++ → Command Line → Additional Options.
 
 ### Diagnostic passes
 

--- a/registration/PluginEntry.cpp
+++ b/registration/PluginEntry.cpp
@@ -30,12 +30,25 @@
 #include "llvm/Passes/PassPlugin.h"
 #endif
 #include "llvm/Support/Compiler.h"
+#include "llvm/Support/CommandLine.h"
 
 #include "llvm/Transforms/Obfuscator.h"
 #include "llvm/Transforms/Obfuscator/ObfuscationAnnotationAnalysis.h"
 #include "llvm/Transforms/Obfuscator/ObfDebug.h" // ObfDumpConfigPass (not in umbrella)
 
 using namespace llvm;
+
+// When set (e.g. `clang -mllvm -enable-obfuscation`), the obfuscation module
+// pass is injected at the start of clang's compile pipeline so annotated
+// functions are obfuscated during a normal `-c` compile -- no opt round-trip.
+// Default off: the extension point adds nothing, so the pipeline is unchanged.
+// The pass itself is annotation-gated (no `obf:` annotations => no-op), so even
+// with this on, un-annotated code is untouched.
+static llvm::cl::opt<bool> EnableObfuscationEP(
+    "enable-obfuscation",
+    llvm::cl::desc("Auto-run the obfuscation module pass in the compile "
+                   "pipeline (annotation-gated; requires obf: annotations)"),
+    llvm::cl::init(false), llvm::cl::Hidden);
 
 // Canonical registration. Wires every name in ObfPasses.inc into the
 // PassBuilder via the new-PM callback surface. Shared by both build modes.
@@ -64,6 +77,17 @@ static void registerObfuscatorPasses(PassBuilder &PB) {
   }
 #include "ObfPasses.inc"
         return false;
+      });
+
+  // Extension-point hook: when -enable-obfuscation is set, run the module
+  // obfuscation entry at pipeline start (before optimization) for every clang
+  // compile. This mirrors the documented opt-then-optimize flow, fires at all
+  // opt levels including -O0, and sees function annotations before inlining.
+  // Off by default => the pipeline is byte-identical.
+  PB.registerPipelineStartEPCallback(
+      [](ModulePassManager &MPM, OptimizationLevel) {
+        if (EnableObfuscationEP)
+          MPM.addPass(ObfuscationModulePass());
       });
 
   // Module analyses (queried by the module pass, e.g. ObfReportAnalysis).


### PR DESCRIPTION
Register a default-off PipelineStart extension point so clang/clang-cl obfuscate annotated functions during a normal -c compile, no opt round-trip. Off by default -> pipeline byte-identical; annotation-gated -> un-annotated code untouched even when on. Fix wrong -mllvm -passes clang recipe in USER.md and add clang-cl/MSBuild usage. Extend CI smoke test to exercise the flag.