### PR TITLE
feat(vm): remove preset=light

### DIFF
--- a/VMPass.cpp
+++ b/VMPass.cpp
@@ -36,20 +36,17 @@ VMPassConfig VMPassConfig::fromPassConfig(const PassConfig& PC) {
 	VMPassConfig Cfg;
 	Cfg.enable = PC.enabled;
 
-	// preset=<light|medium|high|max>: shortcut bundle applied before explicit
-	// knobs below, so any explicit knob in the annotation overrides the preset.
+	// preset=<medium|high|max>: shortcut bundle applied before explicit knobs
+	// below, so any explicit knob in the annotation overrides the preset.
+	// (The former `light` preset was removed: real-lift resilience bench on
+	// v0.8.0 showed it produced NEGATIVE resilience on straight-line code --
+	// attacker's opt-O3 folded the light-preset VM output smaller than the
+	// unobfuscated baseline it was hiding. Anyone who wants the same bundle
+	// can spell it out explicitly.)
 	auto It = PC.params.find("preset");
 	if (It != PC.params.end()) {
 		const std::string& P = It->second;
-		if (P == "light") {
-			// always-on baseline + K=1, no other hardening
-			Cfg.obfRegIdx = true;
-			Cfg.encBytecode = true;
-			Cfg.handlerVariants = 1;
-			Cfg.encDispatch = false;
-			Cfg.strongBytecode = false;
-			Cfg.blindTargets = false;
-		} else if (P == "medium") {
+		if (P == "medium") {
 			// current defaults; explicit for readability + stability
 			Cfg.obfRegIdx = true;
 			Cfg.encBytecode = true;

--- a/docs/VM.md
+++ b/docs/VM.md
@@ -775,10 +775,11 @@ knob still overrides the preset:
 
 | Preset | Bundle |
 |---|---|
-| `light` | Structural virtualisation only — `obfRegIdx`, `encBytecode`, `handlerVariants=1`. |
 | `medium` | Today's defaults — `handlerVariants=3`, `encDispatch`, `strongBytecode`, `blindTargets`. Bit-identical to a bare `vm(...)`. |
 | `high` | `medium` + `hardened` + `threadedDispatch` + `keyedDispatch`. |
 | `max` | `high` + `lazyDecrypt` + `constInStream` + `nestedVM` + `superOps` + `rollingRegKey` + `bindAntiDebug` + `randISA` + `perFnEngine` + `metamorphicEngines`. |
+
+> Note: a former `light` preset was removed. Empirically it produced negative resilience against a binary-lift + `opt -O3` attacker on straight-line code (VM structure folded flatter than the unobfuscated baseline). If you specifically want that knob bundle, spell it out: `vm(obfRegIdx=1, encBytecode=1, handlerVariants=1)`.
 
 **Usage examples:**
 


### PR DESCRIPTION
Real-lift resilience bench on v0.8.0 (remill + opt -O3) showed preset=light gives NEGATIVE resilience on straight-line loops/arith: the attacker's optimizer folds the light-preset VM output smaller than the unobfuscated baseline it was trying to hide (recovery ratio > 100%). The preset was a foot-gun -- anyone reaching for "lightweight virtualisation" got strictly worse than not virtualising at all against a modern static attacker.

- Drop the `if (P == "light")` branch from VMPassConfig::fromPassConfig. Users who specifically want the same knob bundle can spell it explicitly: `vm(obfRegIdx=1, encBytecode=1, handlerVariants=1)`.
- Drop the `light` row from the preset table in docs/VM.md, plus a note explaining the removal.

No impl code deleted: the OFF paths for encDispatch, strongBytecode, blindTargets, handlerVariants=1 stay in place because the P2/P3 individual-feature runtime tests still exercise each with the others off. Only the preset alias is gone.

Regression: 217/221 tests pass; 4 failures are pre-existing rt_budget_* harness gotchas unrelated to this change.