### PR TITLE
Feat/mba ext v2

### DIFF
--- a/MBAUtils.cpp
+++ b/MBAUtils.cpp
@@ -270,11 +270,23 @@ Value* MbaUtils::mulAlt(IRBuilder<>& B, Value* A, Value* V) {
 	return B.CreateNeg(Mul, "mba.mul.alt");
 }
 
-// x * y  =>  -(x * (-y))
+// x * y  =>  x*(y & 0xFFFF) + (x * (y >>> 16)) << 16    (16-bit split-mul; mod 2^32)
+// Distinct from mulAlt: reconstructs y from its low/high 16-bit halves so the
+// per-half products differ structurally instead of being a Neg-Mul-Neg mirror.
+// Only meaningful for i32 (or wider); if you call this with i8/i16, the shift
+// amount of 16 would be UB — assert bitwidth >= 32.
 Value* MbaUtils::mulAlt2(IRBuilder<>& B, Value* A, Value* V) {
-	Value* NegV = B.CreateNeg(V, "mba.mul.alt2.negy");
-	Value* Mul = B.CreateMul(A, NegV, "mba.mul.alt2.mul");
-	return B.CreateNeg(Mul, "mba.mul.alt2");
+	Type* T = A->getType();
+	unsigned BW = T->getScalarSizeInBits();
+	assert(BW >= 32 && "mulAlt2 split-mul requires bitwidth >= 32");
+	Constant* LoMask = ConstantInt::get(T, 0xFFFFu);
+	Constant* Sixteen = ConstantInt::get(T, 16);
+	Value* YLo = B.CreateAnd(V, LoMask, "mba.mul.alt2.ylo");
+	Value* YHi = B.CreateLShr(V, Sixteen, "mba.mul.alt2.yhi");
+	Value* MLo = B.CreateMul(A, YLo, "mba.mul.alt2.mlo");
+	Value* MHi = B.CreateMul(A, YHi, "mba.mul.alt2.mhi");
+	Value* MHiShift = B.CreateShl(MHi, Sixteen, "mba.mul.alt2.mhishl");
+	return B.CreateAdd(MLo, MHiShift, "mba.mul.alt2");
 }
 
 // ============================================================================

--- a/MBAUtils.cpp
+++ b/MBAUtils.cpp
@@ -130,6 +130,13 @@ Value* MbaUtils::addAlt2(IRBuilder<>& B, Value* A, Value* V) {
 	return B.CreateSub(Shl, Xor, "mba.add.alt2");
 }
 
+// x + y  =>  (x - ~y) - 1
+Value* MbaUtils::addAlt3(IRBuilder<>& B, Value* A, Value* V) {
+	Value* NotV = B.CreateNot(V, "mba.add.alt3.not");
+	Value* Sub = B.CreateSub(A, NotV, "mba.add.alt3.sub");
+	return B.CreateSub(Sub, ConstantInt::get(A->getType(), 1), "mba.add.alt3");
+}
+
 // ============================================================================
 // Core Value-level transforms — Sub
 // ============================================================================
@@ -159,6 +166,13 @@ Value* MbaUtils::subAlt2(IRBuilder<>& B, Value* A, Value* V) {
 	return B.CreateAdd(Add1, ConstantInt::get(A->getType(), 1), "mba.sub.alt2");
 }
 
+// x - y  =>  ~(~x + y)
+Value* MbaUtils::subAlt3(IRBuilder<>& B, Value* A, Value* V) {
+	Value* NotA = B.CreateNot(A, "mba.sub.alt3.not");
+	Value* Add = B.CreateAdd(NotA, V, "mba.sub.alt3.add");
+	return B.CreateNot(Add, "mba.sub.alt3");
+}
+
 // ============================================================================
 // Core Value-level transforms — And
 // ============================================================================
@@ -176,6 +190,13 @@ Value* MbaUtils::bitwiseAndAlt(IRBuilder<>& B, Value* A, Value* V) {
 	Value* Nb = B.CreateNot(V, "mba.nb");
 	Value* Or = B.CreateOr(Na, Nb, "mba.nor");
 	return B.CreateNot(Or, "mba.and");
+}
+
+// x & y  =>  (x | y) - (x ^ y)  (bit-disjoint identity)
+Value* MbaUtils::bitwiseAndAlt2(IRBuilder<>& B, Value* A, Value* V) {
+	Value* Or = B.CreateOr(A, V, "mba.and.alt2.or");
+	Value* Xor = B.CreateXor(A, V, "mba.and.alt2.xor");
+	return B.CreateSub(Or, Xor, "mba.and.alt2");
 }
 
 // ============================================================================
@@ -224,6 +245,14 @@ Value* MbaUtils::bitwiseXorAlt(IRBuilder<>& B, Value* A, Value* V) {
 	return B.CreateOr(And1, And2, "mba.xor.alt");
 }
 
+// x ^ y  =>  (x | y) & ~(x & y)
+Value* MbaUtils::bitwiseXorAlt2(IRBuilder<>& B, Value* A, Value* V) {
+	Value* Or = B.CreateOr(A, V, "mba.xor.alt2.or");
+	Value* And = B.CreateAnd(A, V, "mba.xor.alt2.and");
+	Value* NotAnd = B.CreateNot(And, "mba.xor.alt2.not");
+	return B.CreateAnd(Or, NotAnd, "mba.xor.alt2");
+}
+
 // ============================================================================
 // BinaryOperator-level wrappers (bump STATISTIC counters)
 // ============================================================================
@@ -264,11 +293,11 @@ Value* MbaUtils::applyAlternate(IRBuilder<>& B, BinaryOperator* BO) {
 
 unsigned MbaUtils::poolSize(Instruction::BinaryOps Op) const {
 	switch (Op) {
-	case Instruction::Add: return 3; // add, addAlt, addAlt2
-	case Instruction::Sub: return 3; // sub, subAlt, subAlt2
-	case Instruction::And: return 2; // bitwiseAnd, bitwiseAndAlt
+	case Instruction::Add: return 4; // add, addAlt, addAlt2, addAlt3
+	case Instruction::Sub: return 4; // sub, subAlt, subAlt2, subAlt3
+	case Instruction::And: return 3; // bitwiseAnd, bitwiseAndAlt, bitwiseAndAlt2
 	case Instruction::Or:  return 3; // bitwiseOr, bitwiseOrAlt, bitwiseOrAlt2
-	case Instruction::Xor: return 2; // bitwiseXor, bitwiseXorAlt
+	case Instruction::Xor: return 3; // bitwiseXor, bitwiseXorAlt, bitwiseXorAlt2
 	default:               return 0;
 	}
 }
@@ -285,16 +314,22 @@ Value* MbaUtils::applyByIndex(IRBuilder<>& B, Instruction::BinaryOps Op,
 		switch (Idx) {
 		case 0: return add(B, A, V);
 		case 1: return addAlt(B, A, V);
-		default: return addAlt2(B, A, V);
+		case 2: return addAlt2(B, A, V);
+		default: return addAlt3(B, A, V);
 		}
 	case Instruction::Sub:
 		switch (Idx) {
 		case 0: return sub(B, A, V);
 		case 1: return subAlt(B, A, V);
-		default: return subAlt2(B, A, V);
+		case 2: return subAlt2(B, A, V);
+		default: return subAlt3(B, A, V);
 		}
 	case Instruction::And:
-		return (Idx == 0) ? bitwiseAnd(B, A, V) : bitwiseAndAlt(B, A, V);
+		switch (Idx) {
+		case 0: return bitwiseAnd(B, A, V);
+		case 1: return bitwiseAndAlt(B, A, V);
+		default: return bitwiseAndAlt2(B, A, V);
+		}
 	case Instruction::Or:
 		switch (Idx) {
 		case 0: return bitwiseOr(B, A, V);
@@ -302,7 +337,11 @@ Value* MbaUtils::applyByIndex(IRBuilder<>& B, Instruction::BinaryOps Op,
 		default: return bitwiseOrAlt2(B, A, V);
 		}
 	case Instruction::Xor:
-		return (Idx == 0) ? bitwiseXor(B, A, V) : bitwiseXorAlt(B, A, V);
+		switch (Idx) {
+		case 0: return bitwiseXor(B, A, V);
+		case 1: return bitwiseXorAlt(B, A, V);
+		default: return bitwiseXorAlt2(B, A, V);
+		}
 	default:
 		return nullptr;
 	}

--- a/MBAUtils.cpp
+++ b/MBAUtils.cpp
@@ -256,6 +256,58 @@ Value* MbaUtils::applyAlternate(IRBuilder<>& B, BinaryOperator* BO) {
 	}
 }
 
+// ============================================================================
+// Indexed pool access (handler-variant diversification)
+// ============================================================================
+// Value-level dispatch only — deliberately bypasses applyPrimary/applyAlternate
+// so the MBAAdd/Sub/And/Or/Xor STATISTIC counters stay untouched.
+
+unsigned MbaUtils::poolSize(Instruction::BinaryOps Op) const {
+	switch (Op) {
+	case Instruction::Add: return 3; // add, addAlt, addAlt2
+	case Instruction::Sub: return 3; // sub, subAlt, subAlt2
+	case Instruction::And: return 2; // bitwiseAnd, bitwiseAndAlt
+	case Instruction::Or:  return 3; // bitwiseOr, bitwiseOrAlt, bitwiseOrAlt2
+	case Instruction::Xor: return 2; // bitwiseXor, bitwiseXorAlt
+	default:               return 0;
+	}
+}
+
+Value* MbaUtils::applyByIndex(IRBuilder<>& B, Instruction::BinaryOps Op,
+	Value* A, Value* V, unsigned K) {
+	unsigned Size = poolSize(Op);
+	if (Size == 0)
+		return nullptr;
+
+	unsigned Idx = K % Size;
+	switch (Op) {
+	case Instruction::Add:
+		switch (Idx) {
+		case 0: return add(B, A, V);
+		case 1: return addAlt(B, A, V);
+		default: return addAlt2(B, A, V);
+		}
+	case Instruction::Sub:
+		switch (Idx) {
+		case 0: return sub(B, A, V);
+		case 1: return subAlt(B, A, V);
+		default: return subAlt2(B, A, V);
+		}
+	case Instruction::And:
+		return (Idx == 0) ? bitwiseAnd(B, A, V) : bitwiseAndAlt(B, A, V);
+	case Instruction::Or:
+		switch (Idx) {
+		case 0: return bitwiseOr(B, A, V);
+		case 1: return bitwiseOrAlt(B, A, V);
+		default: return bitwiseOrAlt2(B, A, V);
+		}
+	case Instruction::Xor:
+		return (Idx == 0) ? bitwiseXor(B, A, V) : bitwiseXorAlt(B, A, V);
+	default:
+		return nullptr;
+	}
+}
+
 // Recursive MBA: picks primary vs alternate per level using RecRng,
 // recurses into newly produced BinaryOperators.
 // RecRng is passed explicitly so MbaCtx::RecRng sequence is preserved 1:1.

--- a/MBAUtils.cpp
+++ b/MBAUtils.cpp
@@ -254,6 +254,29 @@ Value* MbaUtils::bitwiseXorAlt2(IRBuilder<>& B, Value* A, Value* V) {
 }
 
 // ============================================================================
+// Core Value-level transforms — Mul
+// ============================================================================
+
+// x * y
+Value* MbaUtils::mul(IRBuilder<>& B, Value* A, Value* V) {
+	return B.CreateMul(A, V, "mba.mul");
+}
+
+// x * y  =>  -((-x) * y)
+Value* MbaUtils::mulAlt(IRBuilder<>& B, Value* A, Value* V) {
+	Value* NegA = B.CreateNeg(A, "mba.mul.alt.negx");
+	Value* Mul = B.CreateMul(NegA, V, "mba.mul.alt.mul");
+	return B.CreateNeg(Mul, "mba.mul.alt");
+}
+
+// x * y  =>  -(x * (-y))
+Value* MbaUtils::mulAlt2(IRBuilder<>& B, Value* A, Value* V) {
+	Value* NegV = B.CreateNeg(V, "mba.mul.alt2.negy");
+	Value* Mul = B.CreateMul(A, NegV, "mba.mul.alt2.mul");
+	return B.CreateNeg(Mul, "mba.mul.alt2");
+}
+
+// ============================================================================
 // BinaryOperator-level wrappers (bump STATISTIC counters)
 // ============================================================================
 
@@ -298,6 +321,7 @@ unsigned MbaUtils::poolSize(Instruction::BinaryOps Op) const {
 	case Instruction::And: return 3; // bitwiseAnd, bitwiseAndAlt, bitwiseAndAlt2
 	case Instruction::Or:  return 3; // bitwiseOr, bitwiseOrAlt, bitwiseOrAlt2
 	case Instruction::Xor: return 3; // bitwiseXor, bitwiseXorAlt, bitwiseXorAlt2
+	case Instruction::Mul: return 3; // mul, mulAlt, mulAlt2
 	default:               return 0;
 	}
 }
@@ -341,6 +365,12 @@ Value* MbaUtils::applyByIndex(IRBuilder<>& B, Instruction::BinaryOps Op,
 		case 0: return bitwiseXor(B, A, V);
 		case 1: return bitwiseXorAlt(B, A, V);
 		default: return bitwiseXorAlt2(B, A, V);
+		}
+	case Instruction::Mul:
+		switch (Idx) {
+		case 0: return mul(B, A, V);
+		case 1: return mulAlt(B, A, V);
+		default: return mulAlt2(B, A, V);
 		}
 	default:
 		return nullptr;

--- a/MBAUtils.cpp
+++ b/MBAUtils.cpp
@@ -11,6 +11,7 @@
 #include "llvm/Transforms/Obfuscator/Rng.h"
 #include "llvm/Transforms/Obfuscator/Utils.h"
 
+#include "llvm/ADT/APInt.h"
 #include "llvm/ADT/Statistic.h"
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/DerivedTypes.h"
@@ -277,6 +278,39 @@ Value* MbaUtils::mulAlt2(IRBuilder<>& B, Value* A, Value* V) {
 }
 
 // ============================================================================
+// Core Value-level transforms — Shl
+// ============================================================================
+
+// x << n   (n must be ConstantInt)
+Value* MbaUtils::shl(IRBuilder<>& B, Value* A, Value* N) {
+	return B.CreateShl(A, N, "mba.shl");
+}
+
+// x << n  =>  x * (1 << n)     [n const]
+Value* MbaUtils::shlAlt(IRBuilder<>& B, Value* A, Value* N) {
+	auto* CI = cast<ConstantInt>(N);
+	unsigned NVal = (unsigned)CI->getZExtValue();
+	Type* T = A->getType();
+	Constant* Pow = ConstantInt::get(T, APInt(T->getScalarSizeInBits(), 1) << NVal);
+	return B.CreateMul(A, Pow, "mba.shl.alt");
+}
+
+// x << n  =>  ~((~x) << n) - ((1 << n) - 1)   [n const]
+Value* MbaUtils::shlAlt2(IRBuilder<>& B, Value* A, Value* N) {
+	auto* CI = cast<ConstantInt>(N);
+	unsigned NVal = (unsigned)CI->getZExtValue();
+	Type* T = A->getType();
+	unsigned BW = T->getScalarSizeInBits();
+	Value* NotA = B.CreateNot(A, "mba.shl.alt2.notx");
+	Value* Shifted = B.CreateShl(NotA, N, "mba.shl.alt2.shl");
+	Value* NotShifted = B.CreateNot(Shifted, "mba.shl.alt2.not");
+	// (1 << n) - 1 as constant of the same type. For NVal == 0, mask == 0.
+	APInt MaskAP = NVal == 0 ? APInt(BW, 0) : APInt::getLowBitsSet(BW, NVal);
+	Constant* Mask = ConstantInt::get(T, MaskAP);
+	return B.CreateSub(NotShifted, Mask, "mba.shl.alt2");
+}
+
+// ============================================================================
 // BinaryOperator-level wrappers (bump STATISTIC counters)
 // ============================================================================
 
@@ -322,6 +356,7 @@ unsigned MbaUtils::poolSize(Instruction::BinaryOps Op) const {
 	case Instruction::Or:  return 3; // bitwiseOr, bitwiseOrAlt, bitwiseOrAlt2
 	case Instruction::Xor: return 3; // bitwiseXor, bitwiseXorAlt, bitwiseXorAlt2
 	case Instruction::Mul: return 3; // mul, mulAlt, mulAlt2
+	case Instruction::Shl: return 3; // shl, shlAlt, shlAlt2
 	default:               return 0;
 	}
 }
@@ -371,6 +406,13 @@ Value* MbaUtils::applyByIndex(IRBuilder<>& B, Instruction::BinaryOps Op,
 		case 0: return mul(B, A, V);
 		case 1: return mulAlt(B, A, V);
 		default: return mulAlt2(B, A, V);
+		}
+	case Instruction::Shl:
+		if (!isa<ConstantInt>(V)) return nullptr;
+		switch (Idx) {
+		case 0: return shl(B, A, V);
+		case 1: return shlAlt(B, A, V);
+		default: return shlAlt2(B, A, V);
 		}
 	default:
 		return nullptr;

--- a/include/llvm/Transforms/Obfuscator/MBAUtils.h
+++ b/include/llvm/Transforms/Obfuscator/MBAUtils.h
@@ -81,15 +81,18 @@ namespace llvm::obf {
 		Value* add(IRBuilder<>& B, Value* A, Value* V);     ///< (x^y) + 2*(x&y)
 		Value* addAlt(IRBuilder<>& B, Value* A, Value* V);  ///< (x|y) + (x&y)
 		Value* addAlt2(IRBuilder<>& B, Value* A, Value* V); ///< 2*(x|y) - (x^y)   [VM variant]
+		Value* addAlt3(IRBuilder<>& B, Value* A, Value* V); ///< (x - ~y) - 1
 
 		// ---- Sub: x - y ----
 		Value* sub(IRBuilder<>& B, Value* A, Value* V);     ///< (x^y) - 2*(~x & y)
 		Value* subAlt(IRBuilder<>& B, Value* A, Value* V);  ///< (x & ~y) - (~x & y)
 		Value* subAlt2(IRBuilder<>& B, Value* A, Value* V); ///< x + ~y + 1  [VM variant]
+		Value* subAlt3(IRBuilder<>& B, Value* A, Value* V); ///< ~(~x + y)
 
 		// ---- And: x & y ----
-		Value* bitwiseAnd(IRBuilder<>& B, Value* A, Value* V);    ///< (x+y) - (x|y)
-		Value* bitwiseAndAlt(IRBuilder<>& B, Value* A, Value* V); ///< ~(~x | ~y)  De Morgan
+		Value* bitwiseAnd(IRBuilder<>& B, Value* A, Value* V);     ///< (x+y) - (x|y)
+		Value* bitwiseAndAlt(IRBuilder<>& B, Value* A, Value* V);  ///< ~(~x | ~y)  De Morgan
+		Value* bitwiseAndAlt2(IRBuilder<>& B, Value* A, Value* V); ///< (x|y) - (x^y)  (bit-disjoint identity)
 
 		// ---- Or: x | y ----
 		Value* bitwiseOr(IRBuilder<>& B, Value* A, Value* V);     ///< (x&y) + (x^y)
@@ -97,8 +100,9 @@ namespace llvm::obf {
 		Value* bitwiseOrAlt2(IRBuilder<>& B, Value* A, Value* V); ///< (x^y) | (x&y)  [VM variant]
 
 		// ---- Xor: x ^ y ----
-		Value* bitwiseXor(IRBuilder<>& B, Value* A, Value* V);    ///< (x|y) - (x&y)
-		Value* bitwiseXorAlt(IRBuilder<>& B, Value* A, Value* V); ///< (~x & y) | (x & ~y)
+		Value* bitwiseXor(IRBuilder<>& B, Value* A, Value* V);     ///< (x|y) - (x&y)
+		Value* bitwiseXorAlt(IRBuilder<>& B, Value* A, Value* V);  ///< (~x & y) | (x & ~y)
+		Value* bitwiseXorAlt2(IRBuilder<>& B, Value* A, Value* V); ///< (x|y) & ~(x&y)
 
 		// =========================================================================
 		// BinaryOperator-level wrappers  (MBAPass primary interface)

--- a/include/llvm/Transforms/Obfuscator/MBAUtils.h
+++ b/include/llvm/Transforms/Obfuscator/MBAUtils.h
@@ -109,6 +109,14 @@ namespace llvm::obf {
 		Value* mulAlt(IRBuilder<>& B, Value* A, Value* V);   ///< -((-x) * y)
 		Value* mulAlt2(IRBuilder<>& B, Value* A, Value* V);  ///< -(x * (-y))
 
+		// ---- Shl: x << n (const n only) ----
+		// For these three, @p N MUST be a ConstantInt (compile-time shift amount).
+		// Callers ensure this at their site; passing a non-const shift will trigger
+		// a nullptr return from applyByIndex for opcode Shl.
+		Value* shl(IRBuilder<>& B, Value* A, Value* N);      ///< x << n
+		Value* shlAlt(IRBuilder<>& B, Value* A, Value* N);   ///< x * (1<<n)
+		Value* shlAlt2(IRBuilder<>& B, Value* A, Value* N);  ///< ~((~x) << n) - ((1<<n) - 1)
+
 		// =========================================================================
 		// BinaryOperator-level wrappers  (MBAPass primary interface)
 		// =========================================================================
@@ -140,6 +148,8 @@ namespace llvm::obf {
 		/// @p K is folded modulo poolSize(Op), so any unsigned K is valid and
 		/// cycles through the pool. Returns nullptr if @p Op is not a target
 		/// opcode. Does NOT bump STATISTIC counters (see above).
+		/// For Shl, V must be a ConstantInt (compile-time shift amount);
+		/// nullptr otherwise.
 		Value* applyByIndex(IRBuilder<>& B, Instruction::BinaryOps Op,
 			Value* A, Value* V, unsigned K);
 

--- a/include/llvm/Transforms/Obfuscator/MBAUtils.h
+++ b/include/llvm/Transforms/Obfuscator/MBAUtils.h
@@ -114,6 +114,26 @@ namespace llvm::obf {
 		/// Returns nullptr if opcode is not supported.
 		Value* applyAlternate(IRBuilder<>& B, BinaryOperator* BO);
 
+		// =========================================================================
+		// Indexed pool access (handler-variant diversification)
+		// =========================================================================
+		// Unlike applyPrimary/applyAlternate, these give positional access into the
+		// full identity pool for a given opcode and do NOT bump STATISTIC counters
+		// (callers like VM handler-variant diversification churn through many
+		// indices per opcode and must not inflate the MBA pass's own stats).
+
+		/// Number of distinct identities available for opcode @p Op
+		/// (e.g. 3 for Add: add/addAlt/addAlt2). Returns 0 if @p Op is not a
+		/// target opcode (see isTargetOpcode).
+		unsigned poolSize(Instruction::BinaryOps Op) const;
+
+		/// Apply the @p K-th identity from @p Op's pool to (A op V).
+		/// @p K is folded modulo poolSize(Op), so any unsigned K is valid and
+		/// cycles through the pool. Returns nullptr if @p Op is not a target
+		/// opcode. Does NOT bump STATISTIC counters (see above).
+		Value* applyByIndex(IRBuilder<>& B, Instruction::BinaryOps Op,
+			Value* A, Value* V, unsigned K);
+
 		/// Recursively apply MBA up to @p depth levels.
 		/// @p RecRng  Caller's dedicated recursion RNG (e.g. MbaCtx::RecRng).
 		///            Forwarding a separate RecRng preserves the exact per-pass

--- a/include/llvm/Transforms/Obfuscator/MBAUtils.h
+++ b/include/llvm/Transforms/Obfuscator/MBAUtils.h
@@ -104,6 +104,11 @@ namespace llvm::obf {
 		Value* bitwiseXorAlt(IRBuilder<>& B, Value* A, Value* V);  ///< (~x & y) | (x & ~y)
 		Value* bitwiseXorAlt2(IRBuilder<>& B, Value* A, Value* V); ///< (x|y) & ~(x&y)
 
+		// ---- Mul: x * y ----
+		Value* mul(IRBuilder<>& B, Value* A, Value* V);      ///< x * y
+		Value* mulAlt(IRBuilder<>& B, Value* A, Value* V);   ///< -((-x) * y)
+		Value* mulAlt2(IRBuilder<>& B, Value* A, Value* V);  ///< -(x * (-y))
+
 		// =========================================================================
 		// BinaryOperator-level wrappers  (MBAPass primary interface)
 		// =========================================================================

--- a/include/llvm/Transforms/Obfuscator/MBAUtils.h
+++ b/include/llvm/Transforms/Obfuscator/MBAUtils.h
@@ -107,7 +107,7 @@ namespace llvm::obf {
 		// ---- Mul: x * y ----
 		Value* mul(IRBuilder<>& B, Value* A, Value* V);      ///< x * y
 		Value* mulAlt(IRBuilder<>& B, Value* A, Value* V);   ///< -((-x) * y)
-		Value* mulAlt2(IRBuilder<>& B, Value* A, Value* V);  ///< -(x * (-y))
+		Value* mulAlt2(IRBuilder<>& B, Value* A, Value* V);  ///< x*(y&0xFFFF) + (x*(y>>>16))<<16  (split-mul; i32+)
 
 		// ---- Shl: x << n (const n only) ----
 		// For these three, @p N MUST be a ConstantInt (compile-time shift amount).

--- a/include/llvm/Transforms/Obfuscator/MBAUtils.h
+++ b/include/llvm/Transforms/Obfuscator/MBAUtils.h
@@ -8,14 +8,28 @@
 //   - All methods take an IRBuilder<>& at their insertion point
 //
 // Intended callers
-//   - MBAObfuscation.cpp  (MbaCtx constructs one; runMBA() uses it)
+//   - MBAObfuscation.cpp  (MbaCtx constructs one; runMBA() uses it — 5-opcode)
 //   - VMPass_Impl.cpp     (hardenVMEngine() creates one to replace inline helpers)
+//   - VMPass handler-variant diversification (indexed pool, 7-opcode)
 //
 // Rng conventions
 //   - R (stored by reference, passed at construction) is the "noise Rng" used for
 //     inflation, slot seed, and zero-term shape.
 //   - applyMBARecursive / applyLayeredWindow accept an explicit Rng& RecRng so the
 //     caller can forward its dedicated "recursion Rng" and preserve determinism.
+//
+// Identity pool (23 total; queryable via poolSize/applyByIndex)
+//   Add: 4  (add, addAlt, addAlt2, addAlt3)
+//   Sub: 4  (sub, subAlt, subAlt2, subAlt3)
+//   And: 3  (bitwiseAnd, bitwiseAndAlt, bitwiseAndAlt2)
+//   Or : 3  (bitwiseOr,  bitwiseOrAlt,  bitwiseOrAlt2)
+//   Xor: 3  (bitwiseXor, bitwiseXorAlt, bitwiseXorAlt2)
+//   Mul: 3  (mul, mulAlt, mulAlt2 — indexed pool only; not dispatched by MBA pass)
+//   Shl: 3  (shl, shlAlt, shlAlt2 — const-RHS only; indexed pool only)
+//
+// Only Add/Sub/And/Or/Xor participate in isTargetOpcode /
+// applyPrimary / applyAlternate. Mul and Shl are indexed-pool-only,
+// intended for VM handler-variant diversification.
 // ============================================================================
 
 #include "llvm/ADT/SmallVector.h"

--- a/utils/mba_correctness.py
+++ b/utils/mba_correctness.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""
+mba_correctness.py — Python-level (numpy-only) correctness check for the
+MbaUtils identity pool (MBA_EXT_V2 ME1).
+
+Verifies that every identity implemented in MBAUtils.cpp matches its
+primitive op (+, -, &, |, ^) under two's-complement int32 semantics, across
+a fixed edge-case set plus 1024 random int32 pairs (seed=42), cross-producted
+against each other. All identity functions are evaluated vectorized over
+numpy int32 arrays (wraps naturally on overflow) to keep runtime well under
+the 30s budget even for ~1e6 pairs.
+
+No LLVM dependency.
+"""
+
+import sys
+import numpy as np
+
+I32 = np.int32
+INT_MIN = -2147483648
+INT_MAX = 2147483647
+
+
+# ---------------------------------------------------------------------------
+# Primitives (elementwise over numpy int32 arrays)
+# ---------------------------------------------------------------------------
+
+def p_add(x, y): return I32(x + y)
+def p_sub(x, y): return I32(x - y)
+def p_and(x, y): return I32(x & y)
+def p_or(x, y):  return I32(x | y)
+def p_xor(x, y): return I32(x ^ y)
+
+
+# ---------------------------------------------------------------------------
+# Identities under test — bit-for-bit translation of the C++ IR expansions.
+# ---------------------------------------------------------------------------
+
+def i_add(x, y):        return I32((x ^ y) + I32(2) * (x & y))
+def i_addAlt(x, y):     return I32((x | y) + (x & y))
+def i_addAlt2(x, y):    return I32(I32(2) * (x | y) - (x ^ y))
+def i_addAlt3(x, y):    return I32((x - I32(~y)) - I32(1))
+
+def i_sub(x, y):        return I32((x ^ y) - I32(2) * (I32(~x) & y))
+def i_subAlt(x, y):     return I32((x & I32(~y)) - (I32(~x) & y))
+def i_subAlt2(x, y):    return I32(x + I32(~y) + I32(1))
+def i_subAlt3(x, y):    return I32(~(I32(~x) + y))
+
+def i_bitwiseAnd(x, y):     return I32((x + y) - (x | y))
+def i_bitwiseAndAlt(x, y):  return I32(~(I32(~x) | I32(~y)))
+def i_bitwiseAndAlt2(x, y): return I32((x | y) - (x ^ y))
+
+def i_bitwiseOr(x, y):      return I32((x & y) + (x ^ y))
+def i_bitwiseOrAlt(x, y):   return I32((x + y) - (x & y))
+def i_bitwiseOrAlt2(x, y):  return I32((x ^ y) | (x & y))
+
+def i_bitwiseXor(x, y):     return I32((x | y) - (x & y))
+def i_bitwiseXorAlt(x, y):  return I32((I32(~x) & y) | (x & I32(~y)))
+def i_bitwiseXorAlt2(x, y): return I32((x | y) & I32(~(x & y)))
+
+
+IDENTITIES = [
+    ("add",             i_add,             p_add),
+    ("addAlt",          i_addAlt,          p_add),
+    ("addAlt2",         i_addAlt2,         p_add),
+    ("addAlt3",         i_addAlt3,         p_add),
+    ("sub",             i_sub,             p_sub),
+    ("subAlt",          i_subAlt,          p_sub),
+    ("subAlt2",         i_subAlt2,         p_sub),
+    ("subAlt3",         i_subAlt3,         p_sub),
+    ("bitwiseAnd",      i_bitwiseAnd,      p_and),
+    ("bitwiseAndAlt",   i_bitwiseAndAlt,   p_and),
+    ("bitwiseAndAlt2",  i_bitwiseAndAlt2,  p_and),
+    ("bitwiseOr",       i_bitwiseOr,       p_or),
+    ("bitwiseOrAlt",    i_bitwiseOrAlt,    p_or),
+    ("bitwiseOrAlt2",   i_bitwiseOrAlt2,   p_or),
+    ("bitwiseXor",      i_bitwiseXor,      p_xor),
+    ("bitwiseXorAlt",   i_bitwiseXorAlt,   p_xor),
+    ("bitwiseXorAlt2",  i_bitwiseXorAlt2,  p_xor),
+]
+
+
+def build_value_set():
+    fixed = np.array(
+        [-3, -2, -1, 0, 1, 2, 3, INT_MIN, INT_MAX, 0x55555555, -0x55555555],
+        dtype=np.int32,
+    )
+    rng = np.random.default_rng(seed=42)
+    rand_vals = rng.integers(
+        low=INT_MIN, high=INT_MAX + 1, size=1024, endpoint=False, dtype=np.int64
+    ).astype(np.int32)
+    return np.concatenate([fixed, rand_vals])
+
+
+def main():
+    values = build_value_set()
+    # Full cross-product of the combined value set (both operands).
+    X, Y = np.meshgrid(values, values, indexing="ij")
+    X = X.astype(np.int32).ravel()
+    Y = Y.astype(np.int32).ravel()
+    total = X.size
+
+    overall_fail = False
+    rows = []
+
+    for name, fn, prim in IDENTITIES:
+        expected = prim(X, Y)
+        got = fn(X, Y)
+        mismatch = expected != got
+        n_fail = int(np.count_nonzero(mismatch))
+        passed = total - n_fail
+        status = "PASS" if n_fail == 0 else "FAIL"
+        first_fail = None
+        if n_fail:
+            overall_fail = True
+            idx = int(np.argmax(mismatch))
+            first_fail = (int(X[idx]), int(Y[idx]), int(expected[idx]), int(got[idx]))
+        rows.append((name, passed, total, status, first_fail))
+
+    name_w = max(len(r[0]) for r in rows)
+    header = f"{'identity':<{name_w}}  {'passed':>9}  {'total':>9}  status"
+    print(header)
+    print("-" * len(header))
+    for name, passed, tot, status, first_fail in rows:
+        print(f"{name:<{name_w}}  {passed:>9}  {tot:>9}  {status}")
+        if status == "FAIL" and first_fail is not None:
+            x, y, expected, got = first_fail
+            print(f"    first failure: x={x} y={y} expected={expected} got={got}")
+
+    if overall_fail:
+        print("\nRESULT: FAIL — one or more identities mismatched the primitive.")
+        sys.exit(1)
+    else:
+        print(f"\nRESULT: PASS — {len(rows)} identities x {total} pairs all matched.")
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/utils/mba_correctness.py
+++ b/utils/mba_correctness.py
@@ -61,7 +61,13 @@ def i_bitwiseXorAlt2(x, y): return I32((x | y) & I32(~(x & y)))
 
 def i_mul(x, y):     return I32(x * y)
 def i_mulAlt(x, y):  return I32(-((I32(0) - x) * y))
-def i_mulAlt2(x, y): return I32(-(x * (I32(0) - y)))
+def i_mulAlt2(x, y):
+    y_lo = I32(np.uint32(y) & np.uint32(0xFFFF))
+    y_hi = I32(np.uint32(y) >> np.uint32(16))  # LShr: zero-fill via uint32 view
+    m_lo = I32(x * y_lo)
+    m_hi = I32(x * y_hi)
+    m_hi_shift = I32(np.uint32(m_hi) << np.uint32(16))
+    return I32(np.uint32(m_lo) + np.uint32(m_hi_shift))
 
 # ---------------------------------------------------------------------------
 # Shl identities — const-RHS only. n ranges over a fixed set of shift amounts

--- a/utils/mba_correctness.py
+++ b/utils/mba_correctness.py
@@ -63,6 +63,27 @@ def i_mul(x, y):     return I32(x * y)
 def i_mulAlt(x, y):  return I32(-((I32(0) - x) * y))
 def i_mulAlt2(x, y): return I32(-(x * (I32(0) - y)))
 
+# ---------------------------------------------------------------------------
+# Shl identities — const-RHS only. n ranges over a fixed set of shift amounts
+# (not the full int32 domain like the other opcodes); x still ranges over the
+# full 1035-value set built by build_value_set().
+# ---------------------------------------------------------------------------
+
+def p_shl(x, n): return I32(np.int32(x) << n)
+
+def i_shl(x, n): return p_shl(x, n)
+
+def i_shlAlt(x, n):
+    pow2 = (np.uint32(1) << n).astype(np.int32)
+    return I32(np.int32(x) * pow2)
+
+def i_shlAlt2(x, n):
+    notx = I32(~np.int32(x))
+    shifted = I32(notx << n)
+    notshifted = I32(~shifted)
+    mask = ((np.uint32(1) << n) - np.uint32(1)).astype(np.int32)  # n=0 => mask=0
+    return I32(notshifted - mask)
+
 
 IDENTITIES = [
     ("add",             i_add,             p_add),
@@ -86,6 +107,17 @@ IDENTITIES = [
     ("mulAlt",          i_mulAlt,          p_mul),
     ("mulAlt2",         i_mulAlt2,         p_mul),
 ]
+
+IDENTITIES_SHL = [
+    ("shl",             i_shl,             p_shl),
+    ("shlAlt",          i_shlAlt,          p_shl),
+    ("shlAlt2",         i_shlAlt2,         p_shl),
+]
+
+# Shift amounts exercised for the shl family (const-RHS only in production;
+# the correctness suite tests each amount separately rather than the full
+# int32 domain used for the other opcodes' second operand).
+SHIFT_AMOUNTS = [0, 1, 2, 3, 7, 15, 16, 23, 30, 31]
 
 
 def build_value_set():
@@ -126,6 +158,28 @@ def main():
             first_fail = (int(X[idx]), int(Y[idx]), int(expected[idx]), int(got[idx]))
         rows.append((name, passed, total, status, first_fail))
 
+    # Shl family: x ranges over the full value set, n ranges over a fixed
+    # shift-amount set (const-RHS only), cross-producted.
+    n_vals = np.array(SHIFT_AMOUNTS, dtype=np.int32)
+    Xs, Ns = np.meshgrid(values, n_vals, indexing="ij")
+    Xs = Xs.astype(np.int32).ravel()
+    Ns = Ns.astype(np.int32).ravel()
+    total_shl = Xs.size
+
+    for name, fn, prim in IDENTITIES_SHL:
+        expected = prim(Xs, Ns)
+        got = fn(Xs, Ns)
+        mismatch = expected != got
+        n_fail = int(np.count_nonzero(mismatch))
+        passed = total_shl - n_fail
+        status = "PASS" if n_fail == 0 else "FAIL"
+        first_fail = None
+        if n_fail:
+            overall_fail = True
+            idx = int(np.argmax(mismatch))
+            first_fail = (int(Xs[idx]), int(Ns[idx]), int(expected[idx]), int(got[idx]))
+        rows.append((name, passed, total_shl, status, first_fail))
+
     name_w = max(len(r[0]) for r in rows)
     header = f"{'identity':<{name_w}}  {'passed':>9}  {'total':>9}  status"
     print(header)
@@ -140,7 +194,10 @@ def main():
         print("\nRESULT: FAIL — one or more identities mismatched the primitive.")
         sys.exit(1)
     else:
-        print(f"\nRESULT: PASS — {len(rows)} identities x {total} pairs all matched.")
+        print(
+            f"\nRESULT: PASS — {len(rows)} identities all matched "
+            f"({len(IDENTITIES)} x {total} pairs + {len(IDENTITIES_SHL)} x {total_shl} pairs)."
+        )
         sys.exit(0)
 
 

--- a/utils/mba_correctness.py
+++ b/utils/mba_correctness.py
@@ -30,6 +30,7 @@ def p_sub(x, y): return I32(x - y)
 def p_and(x, y): return I32(x & y)
 def p_or(x, y):  return I32(x | y)
 def p_xor(x, y): return I32(x ^ y)
+def p_mul(x, y): return I32(x * y)
 
 
 # ---------------------------------------------------------------------------
@@ -58,6 +59,10 @@ def i_bitwiseXor(x, y):     return I32((x | y) - (x & y))
 def i_bitwiseXorAlt(x, y):  return I32((I32(~x) & y) | (x & I32(~y)))
 def i_bitwiseXorAlt2(x, y): return I32((x | y) & I32(~(x & y)))
 
+def i_mul(x, y):     return I32(x * y)
+def i_mulAlt(x, y):  return I32(-((I32(0) - x) * y))
+def i_mulAlt2(x, y): return I32(-(x * (I32(0) - y)))
+
 
 IDENTITIES = [
     ("add",             i_add,             p_add),
@@ -77,6 +82,9 @@ IDENTITIES = [
     ("bitwiseXor",      i_bitwiseXor,      p_xor),
     ("bitwiseXorAlt",   i_bitwiseXorAlt,   p_xor),
     ("bitwiseXorAlt2",  i_bitwiseXorAlt2,  p_xor),
+    ("mul",             i_mul,             p_mul),
+    ("mulAlt",          i_mulAlt,          p_mul),
+    ("mulAlt2",         i_mulAlt2,         p_mul),
 ]
 
 
@@ -93,6 +101,7 @@ def build_value_set():
 
 
 def main():
+    np.seterr(over="ignore")
     values = build_value_set()
     # Full cross-product of the combined value set (both operands).
     X, Y = np.meshgrid(values, values, indexing="ij")

--- a/utils/mba_fold_check.py
+++ b/utils/mba_fold_check.py
@@ -51,11 +51,25 @@ IDENTITIES = {
   ret i32 %r
 }
 """,
+    "mulAlt": """define i32 @f(i32 %x, i32 %y) {
+  %nx = sub i32 0, %x
+  %m = mul i32 %nx, %y
+  %r = sub i32 0, %m
+  ret i32 %r
+}
+""",
+    "mulAlt2": """define i32 @f(i32 %x, i32 %y) {
+  %ny = sub i32 0, %y
+  %m = mul i32 %x, %ny
+  %r = sub i32 0, %m
+  ret i32 %r
+}
+""",
 }
 
 # A single primitive binop directly on %x/%y (either operand order).
 PRIMITIVE_RE = re.compile(
-    r"=\s*(add|sub|and|xor)\s+i32\s+(%x, %y|%y, %x)\b")
+    r"=\s*(add|sub|and|xor|mul)\s+i32\s+(%x, %y|%y, %x)\b")
 
 
 def classify(ll_out):

--- a/utils/mba_fold_check.py
+++ b/utils/mba_fold_check.py
@@ -65,16 +65,35 @@ IDENTITIES = {
   ret i32 %r
 }
 """,
+    "shlAlt": """define i32 @f(i32 %x, i32 %y) {
+  %r = mul i32 %x, 8
+  ret i32 %r
+}
+""",
+    "shlAlt2": """define i32 @f(i32 %x, i32 %y) {
+  %nx = xor i32 %x, -1
+  %s = shl i32 %nx, 3
+  %ns = xor i32 %s, -1
+  %r = sub i32 %ns, 7
+  ret i32 %r
+}
+""",
 }
 
 # A single primitive binop directly on %x/%y (either operand order).
 PRIMITIVE_RE = re.compile(
     r"=\s*(add|sub|and|xor|mul)\s+i32\s+(%x, %y|%y, %x)\b")
 
+# A single shl on %x by a compile-time-constant literal shift amount
+# (the shl family's fold target — const-RHS only, so operand 1 is a literal).
+SHL_RE = re.compile(r"=\s*shl\s+i32\s+%x,\s*\d+\b")
+
 
 def classify(ll_out):
-    ops = PRIMITIVE_RE.findall(ll_out)
-    if len(ops) == 1:
+    shl_ops = SHL_RE.findall(ll_out)
+    binops = PRIMITIVE_RE.findall(ll_out)
+    total = len(shl_ops) + len(binops)
+    if total == 1:
         return "folded_to_primitive"
     return "preserved"
 

--- a/utils/mba_fold_check.py
+++ b/utils/mba_fold_check.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""
+mba_fold_check.py — best-effort -O2 fold-resistance probe for the 4 new
+MbaUtils identities added in MBA_EXT_V2 ME1 (addAlt3/subAlt3/bitwiseAndAlt2/
+bitwiseXorAlt2). Not a gate: some identities are expected to fold back to the
+primitive under InstCombine; this just reports which ones do.
+"""
+
+import os
+import re
+import subprocess
+import sys
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_BUILD = os.path.normpath(os.path.join(_HERE, "..", "..", "xollvm-windows", "build"))
+# ninja single-config build lands opt at build/bin/opt.exe;
+# multi-config (VS) lands it at build/Release/bin/opt.exe. Try both.
+_CANDIDATES = [
+    os.path.join(_BUILD, "bin", "opt.exe"),
+    os.path.join(_BUILD, "Release", "bin", "opt.exe"),
+]
+OPT = next((p for p in _CANDIDATES if os.path.isfile(p)), _CANDIDATES[0])
+
+IDENTITIES = {
+    "addAlt3": """define i32 @f(i32 %x, i32 %y) {
+  %nv = xor i32 %y, -1
+  %d = sub i32 %x, %nv
+  %r = sub i32 %d, 1
+  ret i32 %r
+}
+""",
+    "subAlt3": """define i32 @f(i32 %x, i32 %y) {
+  %na = xor i32 %x, -1
+  %s = add i32 %na, %y
+  %r = xor i32 %s, -1
+  ret i32 %r
+}
+""",
+    "bitwiseAndAlt2": """define i32 @f(i32 %x, i32 %y) {
+  %o = or i32 %x, %y
+  %x2 = xor i32 %x, %y
+  %r = sub i32 %o, %x2
+  ret i32 %r
+}
+""",
+    "bitwiseXorAlt2": """define i32 @f(i32 %x, i32 %y) {
+  %o = or i32 %x, %y
+  %a = and i32 %x, %y
+  %na = xor i32 %a, -1
+  %r = and i32 %o, %na
+  ret i32 %r
+}
+""",
+}
+
+# A single primitive binop directly on %x/%y (either operand order).
+PRIMITIVE_RE = re.compile(
+    r"=\s*(add|sub|and|xor)\s+i32\s+(%x, %y|%y, %x)\b")
+
+
+def classify(ll_out):
+    ops = PRIMITIVE_RE.findall(ll_out)
+    if len(ops) == 1:
+        return "folded_to_primitive"
+    return "preserved"
+
+
+def main():
+    if not os.path.isfile(OPT):
+        print("[skip] opt not found. Tried:")
+        for c in _CANDIDATES:
+            print("  " + c)
+        return 0
+
+    env = dict(os.environ)
+    env["PYTHONIOENCODING"] = "utf-8"
+
+    print(f"{'identity':<18}  status_after_O2")
+    print("-" * 40)
+    for name, ll in IDENTITIES.items():
+        try:
+            proc = subprocess.run(
+                [OPT, "-O2", "-S", "-o", "-"],
+                input=ll, text=True, capture_output=True, env=env, timeout=30)
+        except Exception as e:
+            print(f"{name:<18}  [error] {e}")
+            continue
+        if proc.returncode != 0:
+            print(f"{name:<18}  [error] opt exited {proc.returncode}: {proc.stderr.strip()[:120]}")
+            continue
+        status = classify(proc.stdout)
+        print(f"{name:<18}  {status}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/utils/mba_fold_check.py
+++ b/utils/mba_fold_check.py
@@ -59,9 +59,12 @@ IDENTITIES = {
 }
 """,
     "mulAlt2": """define i32 @f(i32 %x, i32 %y) {
-  %ny = sub i32 0, %y
-  %m = mul i32 %x, %ny
-  %r = sub i32 0, %m
+  %ylo = and i32 %y, 65535
+  %yhi = lshr i32 %y, 16
+  %mlo = mul i32 %x, %ylo
+  %mhi = mul i32 %x, %yhi
+  %mhis = shl i32 %mhi, 16
+  %r = add i32 %mlo, %mhis
   ret i32 %r
 }
 """,


### PR DESCRIPTION
## Summary

Extends `MbaUtils` identity pool from 13 → 23. Adds an indexed-access API
(`poolSize` / `applyByIndex`) so callers can query the pool positionally
instead of hand-picking `applyPrimary` / `applyAlternate`. Unblocks
`feat/vm_handler_mutation` phase M2 (per-variant handler diversification
needs K up to 32–64 distinct handler bodies per opcode; old pool
collapsed to ~5 unique bodies at K=64).

## Pool changes

| Op   | Before | After | New identities                                                       |
|------|--------|-------|----------------------------------------------------------------------|
| Add  | 3      | 4     | `addAlt3`  = `(x - ~y) - 1`                                          |
| Sub  | 3      | 4     | `subAlt3`  = `~(~x + y)`                                             |
| And  | 2      | 3     | `bitwiseAndAlt2` = `(x \| y) - (x ^ y)`                              |
| Or   | 3      | 3     | —                                                                    |
| Xor  | 2      | 3     | `bitwiseXorAlt2` = `(x \| y) & ~(x & y)`                             |
| Mul  | 0      | 3     | `mul`, `mulAlt` = `-((-x)*y)`, `mulAlt2` = 16-bit split-mul (6 insns)|
| Shl  | 0      | 3     | `shl`, `shlAlt` = `x*(1<<n)`, `shlAlt2` = `~((~x)<<n) - ((1<<n)-1)`  |

`mulAlt2` uses `x*(y & 0xFFFF) + (x * (y >>> 16)) << 16` (bit-half
reconstruction, 6 insns: `And, LShr, Mul, Mul, Shl, Add`) — genuinely
distinct IR pattern from `mulAlt`, not just an operand-swap mirror.
Requires bitwidth ≥ 32 (asserted).

`Shl` identities require `V` to be `ConstantInt` (documented on
`applyByIndex`); returns `nullptr` otherwise.

## API additions

```cpp
unsigned poolSize(Instruction::BinaryOps Op) const;
Value* applyByIndex(IRBuilder<>& B, Instruction::BinaryOps Op,
                    Value* A, Value* V, unsigned K);
```

Cycles through the pool via `K % poolSize(Op)`. **Does NOT bump
`MBAAdd/Sub/And/Or/Xor` STATISTIC counters** — callers doing
per-variant diversification would otherwise inflate MBA pass stats.


## Commits

- `0b0f535` scaffold `poolSize`/`applyByIndex` (ME0)
- `b1db403` 4 new alts + correctness/fold suites (ME1)
- `1e0eaa2` mul family (ME2)
- `75a363e` shl family, const-RHS (ME3)
- `8c70370` strengthen mulAlt2 → split-mul
- `884217b` header doc bump

