### PR TITLE
Feat/vm handler mutation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,6 +116,7 @@ set(OBF_SOURCES
   VMPass_Harden.cpp
   VMPass_Nested.cpp
   VMPass_Wrapper.cpp
+  VMPass_Decoys.cpp
   EHUtils.cpp
   TargetCompat.cpp
   FunctionObfContextAnalysis.cpp

--- a/VMPass.cpp
+++ b/VMPass.cpp
@@ -85,6 +85,10 @@ VMPassConfig VMPassConfig::fromPassConfig(const PassConfig& PC) {
 			Cfg.randISA = true;
 			Cfg.perFnEngine = true;         // dedicated engine per virtualized fn
 			Cfg.metamorphicEngines = true;  // distinct handler body per engine
+			// NOTE: handlerVariants=32 / handlerDecoys=2 preset flip deferred
+			// to M6 -- current dispatch materializes K full handler copies per
+			// function (see buildOpcodeHandlers), so K>4 times out `opt` under
+			// preset=max multi-fn until M1 introduces intra-fn variant table.
 		}
 		// Unknown preset name: silently ignore, falls through to defaults +
 		// explicit knobs.
@@ -117,6 +121,7 @@ VMPassConfig VMPassConfig::fromPassConfig(const PassConfig& PC) {
 	getUInt("adHandlerProb", Cfg.adHandlerProb);
 	getBool("bindAntiDebug", Cfg.bindAntiDebug);
 	getUInt("handlerVariants", Cfg.handlerVariants);
+	getUInt("handlerDecoys", Cfg.handlerDecoys);
 	getBool("nestedVM", Cfg.nestedVM);
 	getUInt("nestedVMOpcodes", Cfg.nestedVMOpcodes);
 	getBool("nestedVMHardened", Cfg.nestedVMHardened);
@@ -141,6 +146,7 @@ VMPassConfig VMPassConfig::fromPassConfig(const PassConfig& PC) {
 	if (!Cfg.hardened || !Cfg.antiDebug) Cfg.bindAntiDebug = false;
 	if (Cfg.handlerVariants < 1) Cfg.handlerVariants = 1;
 	if (Cfg.handlerVariants > kMaxHandlerVariants) Cfg.handlerVariants = kMaxHandlerVariants;
+	if (Cfg.handlerDecoys > 3) Cfg.handlerDecoys = 3;
 	if (Cfg.enginePoolSize < 1) Cfg.enginePoolSize = 1;
 	// metamorphicEngines needs >1 engine to diversify across -- either an
 	// explicit pool or per-function engines.

--- a/VMPass.cpp
+++ b/VMPass.cpp
@@ -85,10 +85,12 @@ VMPassConfig VMPassConfig::fromPassConfig(const PassConfig& PC) {
 			Cfg.randISA = true;
 			Cfg.perFnEngine = true;         // dedicated engine per virtualized fn
 			Cfg.metamorphicEngines = true;  // distinct handler body per engine
-			// NOTE: handlerVariants=32 / handlerDecoys=2 preset flip deferred
-			// to M6 -- current dispatch materializes K full handler copies per
-			// function (see buildOpcodeHandlers), so K>4 times out `opt` under
-			// preset=max multi-fn until M1 introduces intra-fn variant table.
+			Cfg.handlerVariants = 4;        // M6: preset flip -- benchmarked K=4/8/16;
+			Cfg.handlerDecoys = 2;          // K=4 is the highest that keeps both opt
+			// AND the downstream clang -O0 compile of the resulting IR under the
+			// 180s harness cap (K=8: opt ~65s ok, but 373x-bloat IR blows clang
+			// -O0 past 180s; K=16: opt itself exceeds 180s). See docs/VM.md
+			// "Handler Polymorphism II" for the full writeup.
 		}
 		// Unknown preset name: silently ignore, falls through to defaults +
 		// explicit knobs.

--- a/VMPass_Decoys.cpp
+++ b/VMPass_Decoys.cpp
@@ -1,0 +1,154 @@
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/Twine.h"
+#include "llvm/IR/BasicBlock.h"
+#include "llvm/IR/Constants.h"
+#include "llvm/IR/DerivedTypes.h"
+#include "llvm/IR/Function.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/Support/Alignment.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include "llvm/Transforms/Obfuscator/VMPass_Impl.h"
+#include "llvm/Transforms/Obfuscator/VMPass_ISA.h"
+#include "llvm/Transforms/Obfuscator/ObfuscationOptions.h"
+
+using namespace llvm;
+
+#define DEBUG_TYPE "vm"
+
+// ============================================================================
+// M3: static decoy handlers
+//
+// Registers NumDecoys extra handler-shaped basic blocks inside the shared
+// vm_engine. Each decoy is built with the exact instruction shapes real
+// handlers use (advIP / rdVR / rdByte / ldVR) so a static lifter sees them
+// as ordinary opcodes, but every result is sunk into a private vm.junk
+// alloca that nothing ever reads back -- the store is dead by construction.
+//
+// Decoys are NEVER reachable from the real dispatch path: buildHandlerTable()
+// appends their blockaddresses past the real handler-table slots, and
+// vm.fetch/emitThreadedTail clamp the fetched opcode index with
+// `P = OIdx % OP_COUNT` before indexing the table, so no decoded opcode byte
+// can ever select a decoy slot. Only the blockaddress-taken keeps them alive
+// through DCE.
+// ============================================================================
+
+namespace {
+	// Private per-engine junk sink. Kept small and power-of-two sized so the
+	// index mask below never needs a bounds check.
+	constexpr unsigned kNJunk = 8;
+} // namespace
+
+
+unsigned VMImpl::computeNumDecoys() const {
+	// Nested VM has its own engine + inner-virtualization loop; decoys would
+	// interact awkwardly with that second dispatch layer, so skip entirely.
+	if (Cfg.nestedVM) {
+		if (Cfg.handlerDecoys != 0 && ObfVerbose)
+			errs() << "[vm] handlerDecoys=" << Cfg.handlerDecoys
+				   << " skipped: nestedVM engine does not support decoys\n";
+		return 0;
+	}
+
+	switch (Cfg.handlerDecoys) {
+		case 1:  return 14;          // ~25% of OP_COUNT (0x38 == 56)
+		case 2:  return 28;          // ~50%
+		case 3:  return kMaxDecoys;  // 32, hard cap
+		default: return 0;           // off (byte-identical)
+	}
+}
+
+
+void VMImpl::buildDecoyHandlers() {
+	DecoyBB.clear();
+	if (NumDecoys == 0)
+		return;
+
+	// vm.junk: allocated once, in the same block (vm.entry) as vm.ip/vm.salt.
+	// Entry has no terminator yet at this point in populateVMEngine() (that
+	// happens later, in buildDispatch()), so appending here lands it right
+	// after the existing allocas/stores.
+	IRBuilder<> EB(Entry);
+	AllocaInst* Junk = EB.CreateAlloca(ArrayType::get(I32Ty, kNJunk),
+		nullptr, "vm.junk");
+	Junk->setAlignment(Align(4));
+	EngineJunk = Junk;
+
+	auto storeJunk = [&](IRBuilder<>& B, unsigned DecoyIdx, Value* V) {
+		Value* Ptr = B.CreateGEP(I32Ty, EngineJunk,
+			B.getInt32(DecoyIdx & (kNJunk - 1)), "vm.dc.jp");
+		B.CreateStore(V, Ptr);
+	};
+
+	for (unsigned DI = 0; DI < NumDecoys; ++DI) {
+		unsigned Template = DI % 3;
+
+		switch (Template) {
+			case 0: {
+				// Template A: ADD-shape.
+				// dst = a + b + pred  (dst/a/b are register-index operands,
+				// pred a plain byte -- same operand mix as OP_BINOP).
+				BasicBlock* BB = BasicBlock::Create(Ctx,
+					"vm.decoy.add." + Twine(DI), HFn);
+				DecoyBB.push_back(BB);
+				IRBuilder<> B(BB);
+				Value* IP = advIP(B, 4);
+				Value* DstIdx = rdVR(B, IP, 0, "vm.dc.d");
+				Value* AIdx = rdVR(B, IP, 1, "vm.dc.a");
+				Value* BIdx = rdVR(B, IP, 2, "vm.dc.b");
+				Value* Pred = rdByte(B, IP, 3, "vm.dc.p");  // already zext'd to i32
+				Value* Sum = B.CreateAdd(ldVR(B, AIdx), ldVR(B, BIdx), "vm.dc.s");
+				Value* R = B.CreateAdd(Sum, Pred, "vm.dc.r");
+				(void)DstIdx;  // decoded like a real dst operand, never stored to
+				storeJunk(B, DI, R);
+				nextInsn(B);
+				break;
+			}
+			case 1: {
+				// Template B: LOAD-shape.
+				// dst/ptr operand mix mirrors OP_LOAD32 (dst:u8 ptrreg:u8), but
+				// the "load" is really a register read, mixed with salt + dst.
+				BasicBlock* BB = BasicBlock::Create(Ctx,
+					"vm.decoy.load." + Twine(DI), HFn);
+				DecoyBB.push_back(BB);
+				IRBuilder<> B(BB);
+				Value* IP = advIP(B, 2);
+				Value* DstIdx = rdVR(B, IP, 0, "vm.dc.d");
+				Value* PtrIdx = rdVR(B, IP, 1, "vm.dc.p");
+				auto* SaltL = B.CreateLoad(I32Ty, EffSalt, "vm.dc.salt");
+				SaltL->setVolatile(true);
+				Value* X = B.CreateXor(ldVR(B, PtrIdx), SaltL, "vm.dc.x1");
+				Value* R = B.CreateXor(X, DstIdx, "vm.dc.r");
+				storeJunk(B, DI, R);
+				nextInsn(B);
+				break;
+			}
+			default: {
+				// Template C: MOV-shape.
+				// dst/src operand mix mirrors OP_MOVR; result is a ROL-7 of the
+				// source register value instead of a plain copy.
+				BasicBlock* BB = BasicBlock::Create(Ctx,
+					"vm.decoy.mov." + Twine(DI), HFn);
+				DecoyBB.push_back(BB);
+				IRBuilder<> B(BB);
+				Value* IP = advIP(B, 2);
+				Value* DstIdx = rdVR(B, IP, 0, "vm.dc.d");
+				Value* SrcIdx = rdVR(B, IP, 1, "vm.dc.s");
+				Value* V = ldVR(B, SrcIdx);
+				Value* Hi = B.CreateShl(V, 7, "vm.dc.hi");
+				Value* Lo = B.CreateLShr(V, 25, "vm.dc.lo");
+				Value* R = B.CreateOr(Hi, Lo, "vm.dc.rol");
+				(void)DstIdx;
+				storeJunk(B, DI, R);
+				nextInsn(B);
+				break;
+			}
+		}
+	}
+
+	LLVM_DEBUG(dbgs() << "[vm] built " << NumDecoys << " decoy handlers\n");
+	if (ObfVerbose)
+		errs() << "[vm] vm_engine decoys: " << NumDecoys << "\n";
+}

--- a/VMPass_Decoys.cpp
+++ b/VMPass_Decoys.cpp
@@ -36,6 +36,12 @@ using namespace llvm;
 // `P = OIdx % OP_COUNT` before indexing the table, so no decoded opcode byte
 // can ever select a decoy slot. Only the blockaddress-taken keeps them alive
 // through DCE.
+//
+// Gated per engine LAYER, not per function request: computeNumDecoys() looks
+// at VMEngine::engineLayer(EngineId), the layer this VMImpl instance is
+// currently populating. The plain engine (layer 0) hosts decoys under
+// preset=max (nestedVM=1) same as always; only the inner nested engine layer
+// (layer 1, its own dispatch loop) skips them.
 // ============================================================================
 
 namespace {
@@ -46,12 +52,17 @@ namespace {
 
 
 unsigned VMImpl::computeNumDecoys() const {
-	// Nested VM has its own engine + inner-virtualization loop; decoys would
-	// interact awkwardly with that second dispatch layer, so skip entirely.
-	if (Cfg.nestedVM) {
+	// populateVMEngine() runs separately per engine layer (plain, then nest
+	// when nestedVM is requested). Decoys are a property of a specific
+	// engine build, not of the function's nestedVM request, so gate on which
+	// layer THIS VMImpl instance is currently populating: the plain engine
+	// (layer 0) always gets decoys per handlerDecoys; only the inner nested
+	// engine layer (layer 1) skips them, since it has its own dispatch loop
+	// that decoys would interact awkwardly with.
+	if (VMEngine::engineLayer(EngineId) != 0) {
 		if (Cfg.handlerDecoys != 0 && ObfVerbose)
 			errs() << "[vm] handlerDecoys=" << Cfg.handlerDecoys
-				   << " skipped: nestedVM engine does not support decoys\n";
+				   << " skipped: nested engine layer does not host decoys\n";
 		return 0;
 	}
 
@@ -168,8 +179,9 @@ void VMImpl::buildDecoyHandlers() {
 // so a lifter/DSE attacker must solve the opaque predicate to prove the
 // decoy edge unreachable.
 //
-// Dormant unless handlerDecoys>=2 AND NumDecoys>0 (nestedVM has NumDecoys==0,
-// see computeNumDecoys()), so handlerDecoys<=1 stays byte-identical to M3.
+// Dormant unless handlerDecoys>=2 AND NumDecoys>0 (the nested engine layer
+// has NumDecoys==0, see computeNumDecoys()), so handlerDecoys<=1 stays
+// byte-identical to M3.
 // ============================================================================
 
 void VMImpl::wireLiveDecoys(Function* EF) {

--- a/VMPass_Decoys.cpp
+++ b/VMPass_Decoys.cpp
@@ -1,3 +1,4 @@
+#include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/Twine.h"
 #include "llvm/IR/BasicBlock.h"
@@ -13,6 +14,8 @@
 #include "llvm/Transforms/Obfuscator/VMPass_Impl.h"
 #include "llvm/Transforms/Obfuscator/VMPass_ISA.h"
 #include "llvm/Transforms/Obfuscator/ObfuscationOptions.h"
+#include "llvm/Transforms/Obfuscator/OpaqueUtils.h"
+#include "llvm/Transforms/Obfuscator/Rng.h"
 
 using namespace llvm;
 
@@ -151,4 +154,88 @@ void VMImpl::buildDecoyHandlers() {
 	LLVM_DEBUG(dbgs() << "[vm] built " << NumDecoys << " decoy handlers\n");
 	if (ObfVerbose)
 		errs() << "[vm] vm_engine decoys: " << NumDecoys << "\n";
+}
+
+
+// ============================================================================
+// M4: live decoys
+//
+// At handlerDecoys>=2, ~50% of variant-tagged handler blocks get an
+// opaque-false-guarded conditional branch into a randomly chosen decoy
+// (DecoyBB). The opaque predicate is always false at runtime, so control
+// always falls through to the original successor -- semantics are exactly
+// preserved -- but the STATIC CFG now shows a real edge into the decoy,
+// so a lifter/DSE attacker must solve the opaque predicate to prove the
+// decoy edge unreachable.
+//
+// Dormant unless handlerDecoys>=2 AND NumDecoys>0 (nestedVM has NumDecoys==0,
+// see computeNumDecoys()), so handlerDecoys<=1 stays byte-identical to M3.
+// ============================================================================
+
+void VMImpl::wireLiveDecoys(Function* EF) {
+	if (!EF || Cfg.handlerDecoys < 2 || NumDecoys == 0)
+		return;
+
+	auto LiveRng = R.fork("vm.decoy.live");
+	llvm::obf::OpaqueUtils Opaque(M, LiveRng, "vm.decoy.live.opq");
+
+	// ---- Skip sets, built once ----------------------------------------
+	SmallPtrSet<const BasicBlock*, 32> DecoySet;
+	for (BasicBlock* BB : DecoyBB)
+		DecoySet.insert(BB);
+
+	// CALL opcode head blocks: not contiguous in the VMOp enum
+	// (0x0F,0x10,0x11,0x2A,0x2B), so list them explicitly rather than
+	// range-scanning. CALL sub-blocks (switch/case/merge/unreachable) are
+	// all caught below by the "vm.cl." name-prefix filter instead.
+	static const VMOp kCallOps[] = {
+		OP_CALL_VOID, OP_CALL_INT, OP_CALL_PTR, OP_CALL_INT64, OP_CALL_F
+	};
+	SmallPtrSet<const BasicBlock*, 16> CallHeadSet;
+	for (VMOp Op : kCallOps)
+		for (unsigned v = 0; v < NumVariants; ++v)
+			if (OpcBB[Op][v])
+				CallHeadSet.insert(OpcBB[Op][v]);
+
+	// ---- Collection pass (do not mutate the CFG while walking it) -----
+	SmallVector<std::pair<BasicBlock*, unsigned>, 128> Sites;
+	for (BasicBlock& BB : *EF) {
+		if (VariantOf.count(&BB) == 0) continue;             // dispatch/fetch/exit/etc
+		if (DecoySet.count(&BB)) continue;                   // never nest into a decoy
+		if (CallHeadSet.count(&BB)) continue;                // CALL head (belt-and-braces)
+		if (BB.getName().starts_with("vm.cl.")) continue;    // CALL sub-blocks
+
+		Instruction* Term = BB.getTerminator();
+		auto* Br = dyn_cast_or_null<BranchInst>(Term);
+		if (!Br) continue;                                   // only br / condbr terminators
+
+		if (LiveRng.range(2) != 0) continue;                 // ~50% density
+		unsigned DecoyIdx = LiveRng.range(NumDecoys);
+		Sites.emplace_back(&BB, DecoyIdx);
+	}
+
+	// ---- Rewrite pass --------------------------------------------------
+	for (auto& Site : Sites) {
+		BasicBlock* BB = Site.first;
+		unsigned DecoyIdx = Site.second;
+
+		Instruction* Term = BB->getTerminator();
+		BasicBlock* Post = BB->splitBasicBlock(Term, "m4post");
+
+		// BB now ends in an unconditional `br Post` (added by splitBasicBlock).
+		// Replace it with an opaque-false-guarded condbr into the decoy;
+		// the opaque predicate is always false at runtime so Post is always
+		// taken -- semantics unchanged, static CFG grows a decoy edge.
+		Instruction* SplitBr = BB->getTerminator();
+		SplitBr->eraseFromParent();
+
+		IRBuilder<> B(BB);
+		Value* Pred = Opaque.randomHardFalse(B);
+		B.CreateCondBr(Pred, DecoyBB[DecoyIdx], Post);
+	}
+
+	LLVM_DEBUG(dbgs() << "[vm] wireLiveDecoys: " << Sites.size()
+		<< " handler blocks wired to live decoys\n");
+	if (ObfVerbose)
+		errs() << "[vm] vm_engine live decoys wired: " << Sites.size() << "\n";
 }

--- a/VMPass_Dispatch.cpp
+++ b/VMPass_Dispatch.cpp
@@ -34,14 +34,17 @@ using namespace llvm;
 
 
 void VMImpl::buildHandlerTable() {
-	// table is [OP_COUNT+1 x ptr].  Slots 0..OP_COUNT-1 hold
-	// permuted BlockAddress entries (existing).  Slot [OP_COUNT] holds the
-	// engine function pointer — the wrapper loads it and makes an indirect
-	// call, breaking static call-site xref analysis.
+	// table is [OP_COUNT*K + 1 x ptr] (+ OP_COUNT more when encDispatch is
+	// on).  Slots [P*K .. P*K+K-1] hold the K variant BlockAddress entries
+	// for physical opcode P (M1: intra-function handler-variant dispatch --
+	// all K variant bodies are reachable per opcode; vm.fetch selects one at
+	// runtime from (ip, salt)).  Slot [OP_COUNT*K] holds the engine function
+	// pointer — the wrapper loads it and makes an indirect call, breaking
+	// static call-site xref analysis.
 	//
 	// NOTE: The pointer is stored unmasked here because LLVM 21 does not
 	// support xor(ptrtoint) in constant-expression global initialisers.
-	// The handler table already contains 51 blockaddress(@__vm_engine,...)
+	// The handler table already contains many blockaddress(@__vm_engine,...)
 	// entries so one more raw ptr adds no new information for the analyst.
 	// (constant blinding) will obfuscate the wrapper's runtime
 	// load path so the connection is not trivially visible in the wrapper.
@@ -53,18 +56,13 @@ void VMImpl::buildHandlerTable() {
 	bool ED = SharedEngineMode ? SS->EncDispatch : EncDispatch;
 
 	// P2: table size grows to hold the encrypted dispatch map (dmap) when
-	// encDispatch is on. Off (default): TableSize == OP_COUNT+1, byte-identical
-	// to pre-P2.
-	unsigned TableSize = ED ? (2u * OP_COUNT + 1u) : (OP_COUNT + 1u);
-	SmallVector<Constant*, 2 * OP_COUNT + 1> Es;
+	// encDispatch is on. M1: base size grows from OP_COUNT+1 to OP_COUNT*K+1.
+	// At K==1 this is byte-identical to pre-M1 (TableSize == OP_COUNT+1).
+	unsigned TableSize = ED ? (OP_COUNT * K + 1u + OP_COUNT) : (OP_COUNT * K + 1u);
+	SmallVector<Constant*, 128> Es;
 	Es.resize(TableSize, nullptr);
 
-	// Per-function random variant selection: fork does NOT consume the
-	// parent RNG stream, so at K==1 (vsel always 0, .range() never called)
-	// this is fully dormant and byte-identical to pre-variant behavior.
-	auto VarRng = R.fork("vm.handler.variant");
-
-	// P2: secondary Fisher-Yates permutation of handler table slots.
+	// P2: secondary Fisher-Yates permutation of handler table slots (P-space).
 	// Identity when encDispatch is off (dormant, no RNG consumption).
 	uint8_t DispPerm[OP_COUNT];
 	for (unsigned i = 0; i < OP_COUNT; ++i) DispPerm[i] = (uint8_t)i;
@@ -77,43 +75,47 @@ void VMImpl::buildHandlerTable() {
 	}
 
 	for (unsigned L = 0; L < OP_COUNT; ++L) {
-		unsigned vsel = (K > 1) ? VarRng.range(K) : 0;
+		unsigned P = (unsigned)OpMap.encode((VMOp)L);
+		assert(P < OP_COUNT && "opcode map out of range");
+		unsigned PermP = DispPerm[P];               // identity when ED off
 		// CALL handlers wire the module-shared SS->CallSW[RK] switch, which
 		// keeps only the LAST-built variant's switch; ensureCallFTyCases()
 		// extends only that one as later functions register new FunctionTypes.
-		// Selecting any earlier CALL variant would route through a switch that
-		// never received those cases -> default (vm.cl.ur, unreachable) -> UB.
-		// Pin CALL opcodes to the last variant (K-1); all other opcodes keep
-		// full per-function variant diversity.
-		if (K > 1 && (L == OP_CALL_VOID || L == OP_CALL_INT || L == OP_CALL_PTR ||
-					  L == OP_CALL_INT64 || L == OP_CALL_F))
-			vsel = K - 1;
-		BasicBlock* HB = SharedEngineMode ? SS->OpcBB[L][vsel]
-										   : OpcBB[L][vsel];
-		assert(HB && "missing opcode handler variant");
-		unsigned P = (unsigned)OpMap.encode((VMOp)L);
-		assert(P < OP_COUNT && "opcode map out of range");
-		unsigned slot = DispPerm[P];               // identity when ED off
-		Es[slot] = BlockAddress::get(BAFn, HB);
+		// Routing to any earlier CALL variant would hit a switch that never
+		// received those cases -> default (vm.cl.ur, unreachable) -> UB.
+		// Pin ALL K slots for CALL opcodes to the last variant (K-1) so
+		// runtime vsel can never select an unwired CALL variant; all other
+		// opcodes keep full intra-function variant diversity.
+		bool IsCall = (L == OP_CALL_VOID || L == OP_CALL_INT || L == OP_CALL_PTR ||
+					   L == OP_CALL_INT64 || L == OP_CALL_F);
+		for (unsigned v = 0; v < K; ++v) {
+			unsigned VB = (K > 1 && IsCall) ? (K - 1) : v;
+			BasicBlock* HB = SharedEngineMode ? SS->OpcBB[L][VB]
+											   : OpcBB[L][VB];
+			assert(HB && "missing opcode handler variant");
+			Es[PermP * K + v] = BlockAddress::get(BAFn, HB);
+		}
 	}
-	for (unsigned P = 0; P < OP_COUNT; ++P)
-		assert(Es[P] && "unfilled handler table slot");
+	for (unsigned i = 0; i < OP_COUNT * K; ++i)
+		assert(Es[i] && "unfilled handler table slot");
 
-	// engine pointer in slot [OP_COUNT]
+	// engine pointer in slot [OP_COUNT*K]
 	{
 		Function* EngFn = M.getFunction(VMEngine::vmEngineName(EngineId));
 		assert(EngFn && "vm_engine must exist before building handler table");
-		Es[OP_COUNT] = EngFn;
+		Es[OP_COUNT * K] = EngFn;
 	}
 
-	// P2: encrypted dispatch map (dmap) occupies slots [OP_COUNT+1 .. 2*OP_COUNT].
-	// dmap[P] = DispPerm[P] XOR SaltConst, stored as an inttoptr constant expr
-	// (LLVM allows ConstantExpr::getIntToPtr in global initializers; ptrtoint
-	// recovers the integer at runtime).
+	// P2: encrypted dispatch map (dmap) occupies slots
+	// [OP_COUNT*K+1 .. OP_COUNT*K+OP_COUNT]. dmap[P] = DispPerm[P] XOR
+	// SaltConst (semantics UNCHANGED from pre-M1 -- still indexed per-P;
+	// vm.fetch multiplies the decoded value by K after decrypt), stored as
+	// an inttoptr constant expr (LLVM allows ConstantExpr::getIntToPtr in
+	// global initializers; ptrtoint recovers the integer at runtime).
 	if (ED) {
 		for (unsigned P = 0; P < OP_COUNT; ++P) {
 			uint64_t enc = (uint64_t)((uint32_t)DispPerm[P] ^ SaltConst);
-			Es[OP_COUNT + 1 + P] =
+			Es[OP_COUNT * K + 1 + P] =
 				ConstantExpr::getIntToPtr(ConstantInt::get(I64Ty, enc), PtrTy);
 		}
 	}
@@ -187,11 +189,14 @@ void VMImpl::buildDispatch() {
 		Value* P = B.CreateURem(OIdx, B.getInt32(OP_COUNT), "vm.safe");
 
 		// P2: route through the encrypted dispatch map (dmap) when encDispatch
-		// is on. dmap lives at handlers[OP_COUNT+1 + P]; decrypt with the
-		// runtime salt to recover the permuted table slot.
+		// is on. dmap lives at handlers[OP_COUNT*K+1 + P] (M1: base table grew
+		// to OP_COUNT*K slots); decrypt with the runtime salt to recover the
+		// permuted P-space slot (semantics unchanged -- runtime multiplies by
+		// NumVariants below, after decode).
 		Value* FinalSlot;
 		if (EncDispatch) {
-			Value* DmIdx  = B.CreateAdd(P, B.getInt32(OP_COUNT + 1), "vm.dm.i");
+			Value* DmIdx  = B.CreateAdd(P,
+				B.getInt32(OP_COUNT * NumVariants + 1), "vm.dm.i");
 			Value* DmPtr  = B.CreateGEP(PtrTy, EffHandlers, DmIdx, "vm.dm.p");
 			Value* DmRaw  = B.CreateLoad(PtrTy, DmPtr, "vm.dm.raw");
 			Value* DmInt  = B.CreateTrunc(
@@ -205,8 +210,38 @@ void VMImpl::buildDispatch() {
 			FinalSlot = P;
 		}
 
-		// GEP into handler table[final_slot]
-		Value* Slot = B.CreateGEP(PtrTy, EffHandlers, FinalSlot, "vm.ohsl");
+		// M1: intra-function handler-variant dispatch. Table is now laid
+		// out [P*K + v] per opcode; select v at runtime from (ip, salt) so
+		// different dispatches of the same opcode can reach different
+		// variant bodies. Guarded on NumVariants > 1 -- emits no new IR and
+		// leaves the GEP consuming FinalSlot verbatim when K==1 (identity,
+		// byte-identical to pre-M1).
+		//
+		// Uses the raw incoming "salt" ARGUMENT (HFn->getArg(kParamSalt)),
+		// not a load from EffSalt/SS->EngineSalt: hardenVMEngine()'s RDTSC
+		// handler-timing traps XOR-poison that alloca on a suspected debugger
+		// (a documented, load-sensitive false-positive risk). Pre-M1, nothing
+		// in this code path read that alloca unless keyedDispatch/encDispatch
+		// (opt-in, off by default) were on, so a false trip was control-flow
+		// inert here. Reading it for vsel would make EVERY default VM build
+		// (handlerVariants=3) newly control-flow-sensitive to that flake.
+		// The argument SSA value is immutable and dominates the whole
+		// function, so it is never affected by the poison store.
+		Value* TableSlot = FinalSlot;
+		if (NumVariants > 1) {
+			Value* SaltL = HFn->getArg(VMEngine::kParamSalt);
+			Value* Mix = B.CreateXor(
+				B.CreateMul(IP, B.getInt32(0x9E3779B1u), "vm.vs.mul"),
+				B.CreateLShr(SaltL, B.getInt32(3), "vm.vs.shr"),
+				"vm.vs.mix");
+			Value* VSel = B.CreateURem(Mix, B.getInt32(NumVariants), "vm.vs.sel");
+			TableSlot = B.CreateAdd(
+				B.CreateMul(FinalSlot, B.getInt32(NumVariants), "vm.vs.base"),
+				VSel, "vm.vs.slot");
+		}
+
+		// GEP into handler table[table_slot]
+		Value* Slot = B.CreateGEP(PtrTy, EffHandlers, TableSlot, "vm.ohsl");
 		Value* Hndl = B.CreateLoad(PtrTy, Slot, "vm.hndl");
 
 		// indirectbr with all opcode blocks (all variants) declared as successors
@@ -270,7 +305,8 @@ void VMImpl::emitThreadedTail(IRBuilder<>& B) {
 	// is on -- mirrors buildDispatch()'s vm.fetch logic exactly.
 	Value* FinalSlot;
 	if (EncDispatch) {
-		Value* DmIdx = FB.CreateAdd(P, FB.getInt32(OP_COUNT + 1), "vm.dm.i");
+		Value* DmIdx = FB.CreateAdd(P,
+			FB.getInt32(OP_COUNT * NumVariants + 1), "vm.dm.i");
 		Value* DmPtr = FB.CreateGEP(PtrTy, EffHandlers, DmIdx, "vm.dm.p");
 		Value* DmRaw = FB.CreateLoad(PtrTy, DmPtr, "vm.dm.raw");
 		Value* DmInt = FB.CreateTrunc(
@@ -284,8 +320,27 @@ void VMImpl::emitThreadedTail(IRBuilder<>& B) {
 		FinalSlot = P;
 	}
 
-	// GEP into handler table[final_slot]
-	Value* Slot = FB.CreateGEP(PtrTy, EffHandlers, FinalSlot, "vm.ohsl");
+	// M1: intra-function handler-variant dispatch -- mirrors buildDispatch()'s
+	// vm.fetch logic exactly. Guarded on NumVariants > 1; identity (no new
+	// IR, GEP consumes FinalSlot verbatim) when K==1. Uses the raw incoming
+	// "salt" ARGUMENT, not a load from EffSalt/SS->EngineSalt -- see the
+	// comment in buildDispatch()'s vm.fetch for why (RDTSC handler-trap
+	// false-positive poisoning of that alloca).
+	Value* TableSlot = FinalSlot;
+	if (NumVariants > 1) {
+		Value* SaltL = HFn->getArg(VMEngine::kParamSalt);
+		Value* Mix = FB.CreateXor(
+			FB.CreateMul(IP2, FB.getInt32(0x9E3779B1u), "vm.vs.mul"),
+			FB.CreateLShr(SaltL, FB.getInt32(3), "vm.vs.shr"),
+			"vm.vs.mix");
+		Value* VSel = FB.CreateURem(Mix, FB.getInt32(NumVariants), "vm.vs.sel");
+		TableSlot = FB.CreateAdd(
+			FB.CreateMul(FinalSlot, FB.getInt32(NumVariants), "vm.vs.base"),
+			VSel, "vm.vs.slot");
+	}
+
+	// GEP into handler table[table_slot]
+	Value* Slot = FB.CreateGEP(PtrTy, EffHandlers, TableSlot, "vm.ohsl");
 	Value* Hndl = FB.CreateLoad(PtrTy, Slot, "vm.hndl");
 
 	// indirectbr with all opcode blocks (all variants) declared as successors

--- a/VMPass_Dispatch.cpp
+++ b/VMPass_Dispatch.cpp
@@ -54,11 +54,15 @@ void VMImpl::buildHandlerTable() {
 	Function* BAFn = SharedEngineMode ? SS->EngineFn : &F;
 	unsigned K = SharedEngineMode ? SS->NumVariants : NumVariants;
 	bool ED = SharedEngineMode ? SS->EncDispatch : EncDispatch;
+	// M3: decoy slot count for this engine (0 = off / nestedVM, mirrors K).
+	unsigned Nd = SharedEngineMode ? SS->NumDecoys : NumDecoys;
 
 	// P2: table size grows to hold the encrypted dispatch map (dmap) when
 	// encDispatch is on. M1: base size grows from OP_COUNT+1 to OP_COUNT*K+1.
-	// At K==1 this is byte-identical to pre-M1 (TableSize == OP_COUNT+1).
-	unsigned TableSize = ED ? (OP_COUNT * K + 1u + OP_COUNT) : (OP_COUNT * K + 1u);
+	// M3: Nd more slots appended past the dmap (or past the engine-ptr slot
+	// when encDispatch is off) for decoy blockaddresses. At K==1, Nd==0 this
+	// is byte-identical to pre-M1 (TableSize == OP_COUNT+1).
+	unsigned TableSize = OP_COUNT * K + 1u + (ED ? OP_COUNT : 0u) + Nd;
 	SmallVector<Constant*, 128> Es;
 	Es.resize(TableSize, nullptr);
 
@@ -120,8 +124,21 @@ void VMImpl::buildHandlerTable() {
 		}
 	}
 
+	// M3: decoy blockaddresses occupy the tail Nd slots, past the dmap (or
+	// past the engine-ptr slot when encDispatch is off). Never referenced by
+	// vm.fetch/emitThreadedTail (P is clamped mod OP_COUNT before indexing),
+	// so these slots exist purely for a static lifter to trip over.
+	{
+		unsigned DecoyBase = OP_COUNT * K + 1u + (ED ? OP_COUNT : 0u);
+		BasicBlock* const* DBB = SharedEngineMode ? SS->DecoyBB.data() : DecoyBB.data();
+		for (unsigned i = 0; i < Nd; ++i) {
+			assert(DBB[i] && "missing decoy handler block");
+			Es[DecoyBase + i] = BlockAddress::get(BAFn, DBB[i]);
+		}
+	}
+
 	for (unsigned i = 0; i < TableSize; ++i)
-		assert(Es[i] && "unfilled handler table slot (incl. dmap)");
+		assert(Es[i] && "unfilled handler table slot (incl. dmap/decoys)");
 
 	auto* ATy = ArrayType::get(PtrTy, TableSize);
 	GVHandlers = new GlobalVariable(M, ATy, true, GlobalValue::PrivateLinkage,
@@ -598,6 +615,17 @@ void VMImpl::populateVMEngine() {
 	// Make this pool clone's handler bodies distinct from the other engines'
 	// (per-clone MBA, seeded by EngineId). No-op unless metamorphicEngines is on.
 	metamorphRewriteEngine(EF);
+
+	// M3: static decoy handlers. computeNumDecoys() returns 0 when
+	// handlerDecoys==0 or nestedVM==1 -- buildDecoyHandlers() is then a
+	// no-op that touches no IR (byte-identical to pre-M3 output).
+	NumDecoys = computeNumDecoys();
+	buildDecoyHandlers();
+	SS->NumDecoys = NumDecoys;
+	SS->EngineJunk = EngineJunk;
+	SS->DecoyBB.clear();
+	for (unsigned i = 0; i < NumDecoys; ++i)
+		SS->DecoyBB.push_back(DecoyBB[i]);
 
 	SS->NumVariants = NumVariants;
 	SS->EncDispatch = EncDispatch;

--- a/VMPass_Dispatch.cpp
+++ b/VMPass_Dispatch.cpp
@@ -627,6 +627,10 @@ void VMImpl::populateVMEngine() {
 	for (unsigned i = 0; i < NumDecoys; ++i)
 		SS->DecoyBB.push_back(DecoyBB[i]);
 
+	// M4: live decoys. No-op unless handlerDecoys>=2 AND NumDecoys>0 (see
+	// wireLiveDecoys' own guard), so handlerDecoys<=1 stays byte-identical.
+	wireLiveDecoys(EF);
+
 	SS->NumVariants = NumVariants;
 	SS->EncDispatch = EncDispatch;
 	SS->LazyMode = LazyDecrypt;

--- a/VMPass_Harden.cpp
+++ b/VMPass_Harden.cpp
@@ -392,6 +392,7 @@ void VMImpl::diversifyHandlerVariants(Function* EF) {
 
 	// Collect first (cannot rewrite while iterating).
 	SmallVector<std::pair<BinaryOperator*, unsigned>, 256> Cands;
+	SmallVector<std::pair<ICmpInst*, unsigned>, 128> ICands;
 	for (BasicBlock& BB : *EF) {
 		auto It = VariantOf.find(&BB);
 		if (It == VariantOf.end()) continue;      // not a handler-variant block
@@ -399,8 +400,10 @@ void VMImpl::diversifyHandlerVariants(Function* EF) {
 		for (Instruction& I : BB) {
 			if (auto* BO = dyn_cast<BinaryOperator>(&I)) {
 				if (!BO->getType()->isIntegerTy()) continue;
-				if (!llvm::obf::MbaUtils::isTargetOpcode(BO->getOpcode())) continue;
+				if (MBA.poolSize((Instruction::BinaryOps)BO->getOpcode()) == 0) continue;
 				Cands.push_back({ BO, vi });
+			} else if (auto* IC = dyn_cast<ICmpInst>(&I)) {
+				ICands.push_back({ IC, vi });
 			}
 		}
 	}
@@ -411,26 +414,20 @@ void VMImpl::diversifyHandlerVariants(Function* EF) {
 		IRBuilder<> B(BO);
 		Value* A = BO->getOperand(0);
 		Value* V = BO->getOperand(1);
-		Value* R = nullptr;
+
+		// Commutative-swap pre-mutation: for commutative opcodes, swap the
+		// operand order before feeding the MBA identity so bit (3) of the
+		// variant index widens the diversity space beyond poolSize() --
+		// pure SSA reshape (no IR emitted), correctness-preserving.
 		switch (BO->getOpcode()) {
-		case Instruction::Add:
-			switch (vi % 3) { case 0: R = MBA.add(B, A, V); break;
-							  case 1: R = MBA.addAlt(B, A, V); break;
-							  default: R = MBA.addAlt2(B, A, V); } break;
-		case Instruction::Sub:
-			switch (vi % 3) { case 0: R = MBA.sub(B, A, V); break;
-							  case 1: R = MBA.subAlt(B, A, V); break;
-							  default: R = MBA.subAlt2(B, A, V); } break;
-		case Instruction::Or:
-			switch (vi % 3) { case 0: R = MBA.bitwiseOr(B, A, V); break;
-							  case 1: R = MBA.bitwiseOrAlt(B, A, V); break;
-							  default: R = MBA.bitwiseOrAlt2(B, A, V); } break;
-		case Instruction::And:
-			R = (vi % 2) ? MBA.bitwiseAndAlt(B, A, V) : MBA.bitwiseAnd(B, A, V); break;
-		case Instruction::Xor:
-			R = (vi % 2) ? MBA.bitwiseXorAlt(B, A, V) : MBA.bitwiseXor(B, A, V); break;
+		case Instruction::Add: case Instruction::Mul:
+		case Instruction::And: case Instruction::Or: case Instruction::Xor:
+			if ((vi >> 3) & 1u) std::swap(A, V);
+			break;
 		default: break;
 		}
+
+		Value* R = MBA.applyByIndex(B, (Instruction::BinaryOps)BO->getOpcode(), A, V, vi);
 		if (!R) continue;
 
 		// Variant-unique opaque-zero XOR (matches hardenVMEngine's noise pattern,
@@ -448,12 +445,27 @@ void VMImpl::diversifyHandlerVariants(Function* EF) {
 		++Rewrites;
 	}
 
+	// ICmp arm-invert mutation: swap operands (LLVM auto-inverts the predicate
+	// to preserve semantics) for a bit-selected subset of variant-tagged icmps.
+	// No opaque-zero tail here -- result is i1 and this path never wrapped
+	// icmps in noise even before this change.
+	unsigned IcmpFlips = 0;
+	for (auto& [IC, vi] : ICands) {
+		if (!IC->getParent()) continue; // already erased (shouldn't happen, defensive)
+		if ((vi >> 2) & 1u) {
+			IC->swapOperands();
+			++IcmpFlips;
+		}
+	}
+
 	LLVM_DEBUG(dbgs() << "[vm] diversifyHandlerVariants: " << Rewrites
-		<< " per-variant MBA rewrites across "
+		<< " per-variant MBA rewrites, " << IcmpFlips
+		<< " icmp arm-inverts across "
 		<< NumVariants << " variants\n");
 	if (ObfVerbose)
 		errs() << "[vm] variant-diversify: " << Rewrites
-		<< " MBA rewrites (" << NumVariants << " variants)\n";
+		<< " MBA rewrites, " << IcmpFlips
+		<< " icmp flips (" << NumVariants << " variants)\n";
 }
 
 

--- a/VMPass_Wrapper.cpp
+++ b/VMPass_Wrapper.cpp
@@ -567,7 +567,8 @@ void VMImpl::buildWrapper() {
 	}
 
 	// Call vm_engine (indirect via handler table)
-	// the engine pointer is stored in GVHandlers[OP_COUNT].
+	// the engine pointer is stored in GVHandlers[OP_COUNT*K] (M1: base table
+	// holds K variant slots per opcode -- see VMImpl::buildHandlerTable()).
 	// We load it and make an indirect call.  This eliminates every direct
 	// call-site xref from wrappers to @__vm_engine, breaking static
 	// cross-reference analysis in IDA/Ghidra.
@@ -604,9 +605,13 @@ void VMImpl::buildWrapper() {
 	};
 	if (LazyActive) Args.push_back(LazyCtxArg);              // lazyctx
 
-	// Load engine function pointer from handler table slot [OP_COUNT]
+	// Load engine function pointer from handler table slot [OP_COUNT*K]
+	// (M1: base table now holds K variant slots per opcode -- see
+	// VMImpl::buildHandlerTable(). K is the shared engine's variant count,
+	// not this function's own NumVariants member, which only reflects the
+	// founding function's build.)
 	Value* EngSlot = B.CreateGEP(PtrTy, GVHandlers,
-		blindI32(OP_COUNT), "vm.eng.slot");
+		blindI32(OP_COUNT * SS->NumVariants), "vm.eng.slot");
 	Value* EngPtr = B.CreateLoad(PtrTy, EngSlot, "vm.eng.ptr");
 
 	FunctionType* EngFTy = VMEngine::getVMEngineFunctionType(Ctx, LazyActive);

--- a/docs/USER.md
+++ b/docs/USER.md
@@ -635,7 +635,7 @@ The easiest way in is a **preset** bundle; explicit knobs override it:
 | `light` | Structural virtualisation only. |
 | `medium` | Today's defaults (bit-identical to a bare `vm`). |
 | `high` | `medium` + structural hardening + threaded & IP-keyed dispatch. |
-| `max` | The strongest tier — everything below, plus a private, metamorphic engine per function. |
+| `max` | The strongest tier — everything below, plus a private, metamorphic engine per function, `handlerVariants=4`, and `handlerDecoys=2` (28 static + live decoy handlers on the plain engine; the inner nested engine layer from `nestedVM=1` skips decoys). |
 
 Common knobs (see VM.md for the full list):
 

--- a/docs/VM.md
+++ b/docs/VM.md
@@ -46,6 +46,7 @@ configuration reference, interaction with other passes, debugging, and known lim
   - [Super-operators (superOps)](#super-operators-superops)
   - [Per-build ISA randomisation (randISA)](#per-build-isa-randomisation-randisa)
   - [Engine pool and metamorphic engines](#engine-pool-and-metamorphic-engines)
+  - [Handler Polymorphism II (handlerVariants, handlerDecoys)](#handler-polymorphism-ii-handlervariants-handlerdecoys)
 - [Configuration reference](#configuration-reference)
   - [Presets](#presets)
 - [Interaction with other passes](#interaction-with-other-passes)
@@ -721,6 +722,64 @@ function is understood. These knobs raise that per-lift *multiplier*:
 
 `preset=max` turns on `perFnEngine` + `metamorphicEngines` (see below).
 
+### Handler Polymorphism II (`handlerVariants`, `handlerDecoys`)
+
+`handlerVariants` originally built `K` structurally-distinct copies of each opcode's handler
+body but picked one at *build time* per function — every dispatch of a given opcode inside that
+function landed on the same variant. Four follow-on milestones turned that into genuine
+per-dispatch polymorphism and added decoy handler shapes:
+
+- **Intra-function variant dispatch (M1).** The handler table grows from `OP_COUNT + 1` slots to
+  `OP_COUNT*K + 1` (plus another `OP_COUNT` when `encDispatch` is set for the opcode-index
+  decrypt map), one `blockaddress` per `(opcode, variant)` pair. At runtime `vm.fetch` (and
+  `emitThreadedTail` under `threadedDispatch`) compute `vsel = (ip * 0x9E3779B1 ^ salt >> 3) mod K`
+  and index `handlers[FinalSlot_P*K + vsel]` — so two dispatches of the *same* opcode within one
+  function can land on different handler bodies, not just two different functions. `vsel` reads
+  the engine's immutable incoming salt argument rather than `EffSalt`/`EngineSalt`, which sidesteps
+  `hardened=1`'s RDTSC-driven salt-alloca poisoning. `CALL` opcodes are the one exception: they
+  stay pinned to variant `K-1` across all `K` slots, because the module-shared `CallSW` switch only
+  wires the last-built variant. `K==1` is byte-identical to the pre-M1 output (`mul`/`urem`/`add`
+  for `vsel` are gated out entirely and the table collapses back to `OP_COUNT + 1`).
+- **Strong diversification (M2).** Handler-variant bodies no longer cycle a hand-picked mod-3/
+  mod-2 MBA switch; `diversifyHandlerVariants` now drives `MbaUtils::applyByIndex` over the full
+  23-identity, 7-opcode pool (add/sub/and/or/xor/mul/shl — see `docs/design/MBA_EXT_V2.md`). Two
+  additional structural mutations widen the space further once `K` exceeds the raw pool depth:
+  commutative-swap of the two operands on Add/Mul/And/Or/Xor (bit 3 of the variant index), and
+  ICmp arm-invert via `swapOperands()` on variant-tagged blocks (bit 2 of the variant index). Both
+  are semantics-preserving and dormant at the historical default `handlerVariants=3`; they start
+  firing once `K` is large enough that the pool would otherwise wrap around and repeat.
+- **Static decoys (M3).** `handlerDecoys` ∈ `{0,1,2,3}` registers `{0,14,28,32}` extra
+  handler-shaped basic blocks inside the shared `vm_engine`. Decoy bodies reuse the same
+  instruction primitives real handlers use (`advIP`/`rdVR`/`rdByte`/`ldVR`), so a static lifter
+  sees ordinary-looking opcodes, but every computed result sinks into a private `[8 x i32]
+  vm.junk` alloca that nothing ever reads. Decoys are unreachable via the real fetch path: their
+  `blockaddress`es are appended to the *tail* of the handler table (after real handlers, the
+  engine pointer, and the dmap when `encDispatch` is on), and both dispatch sites clamp the
+  fetched opcode index with `P = OIdx % OP_COUNT` before indexing, so no decoded byte can ever
+  select a decoy slot. `blockaddress`-taken keeps them alive through DCE. Three template shapes
+  (ADD/LOAD/MOV) rotate by `decoyIdx % 3`, each defensively ending in `nextInsn` in case control
+  ever reached one anyway.
+- **Live decoys (M4).** At `handlerDecoys >= 2`, `wireLiveDecoys` instruments ~50% of
+  variant-tagged handler blocks with a conditional branch guarded by an always-false predicate
+  (`OpaqueUtils::randomHardFalse`) targeting one of the M3 decoy blocks — density is driven by a
+  deterministic per-engine RNG fork (`vm.decoy.live`). The static CFG grows a real incoming edge
+  into each targeted decoy; the runtime always takes the real path because the guard resolves to
+  false, so an attacker has to solve the opaque predicate to prove the decoy edge is dead rather
+  than reading it off the CFG. The decoy body still ends in `nextInsn` (M3), so even a
+  successfully-flipped guard loops back into real dispatch instead of hitting UB.
+
+Decoys are gated per engine *layer*, not per function request: `computeNumDecoys()` builds them
+for the plain engine (`__vm_engine`) regardless of whether `nestedVM=1` is also set. Only the
+inner nested engine layer (`__vm_engine.nest`) skips them — it has its own dispatch loop that
+decoys would interact awkwardly with, and that interaction isn't currently validated. So under
+`preset=max` (`nestedVM=1`), `handlerDecoys` still fires: the plain engine gets both static and
+live decoys as normal.
+
+`preset=max` sets `handlerVariants=4, handlerDecoys=2`. Higher `K` was benchmarked and rejected:
+`K=8` keeps `opt` itself under the harness's 180s cap but the resulting ~370x-larger IR then blows
+the downstream `clang -O0` compile past 180s; `K=16` makes `opt` itself exceed 180s. `K=4` is the
+highest value that keeps both steps well inside the cap.
+
 ---
 
 ## Configuration reference
@@ -745,7 +804,8 @@ A `preset=<light|medium|high|max>` bundle (below) is the easy way in; the indivi
 | `regEncrypt` | 0 | 0/1 | Per-slot register-value XOR encryption (layer 3). |
 | `rollingRegKey` | 0 | 0/1 | Evolve the register XOR key as the interpreter runs (with `regEncrypt`). |
 | `hardened` | 0 | 0/1 | Layer-4 structural hardening + layer-5 anti-debug. |
-| `handlerVariants` | 3 | 1–K | Number of structurally-distinct handler-body copies per opcode. |
+| `handlerVariants` | 3 | 1–64 | Number of structurally-distinct handler-body copies per opcode, dispatched per-call via `vsel` (see [Handler Polymorphism II](#handler-polymorphism-ii-handlervariants-handlerdecoys)). |
+| `handlerDecoys` | 0 | 0–3 | Static + live decoy handler blocks (1: 14 static only; 2: 28 static + ~50% opaque-false live guards; 3: reserved). Applies to the plain engine; no effect on the nested engine layer when `nestedVM=1`. |
 | `encDispatch` | 1 | 0/1 | Route dispatch through an encrypted opcode-index map. |
 | `strongBytecode` | 1 | 0/1 | Stronger bytecode obfuscation. |
 | `blindTargets` | 1 | 0/1 | Blind branch/switch targets in the stream. |
@@ -777,7 +837,7 @@ knob still overrides the preset:
 |---|---|
 | `medium` | Today's defaults — `handlerVariants=3`, `encDispatch`, `strongBytecode`, `blindTargets`. Bit-identical to a bare `vm(...)`. |
 | `high` | `medium` + `hardened` + `threadedDispatch` + `keyedDispatch`. |
-| `max` | `high` + `lazyDecrypt` + `constInStream` + `nestedVM` + `superOps` + `rollingRegKey` + `bindAntiDebug` + `randISA` + `perFnEngine` + `metamorphicEngines`. |
+| `max` | `high` + `lazyDecrypt` + `constInStream` + `nestedVM` + `superOps` + `rollingRegKey` + `bindAntiDebug` + `randISA` + `perFnEngine` + `metamorphicEngines` + `handlerVariants=4` + `handlerDecoys=2`. `handlerDecoys` fires on the plain engine as normal alongside `nestedVM` — only the inner nested engine layer skips decoys (see [Handler Polymorphism II](#handler-polymorphism-ii-handlervariants-handlerdecoys)). |
 
 > Note: a former `light` preset was removed. Empirically it produced negative resilience against a binary-lift + `opt -O3` attacker on straight-line code (VM structure folded flatter than the unobfuscated baseline). If you specifically want that knob bundle, spell it out: `vm(obfRegIdx=1, encBytecode=1, handlerVariants=1)`.
 

--- a/docs/obf_annotations.h
+++ b/docs/obf_annotations.h
@@ -312,7 +312,14 @@
  *                            per function.
  *   minBlocks        (1)     don't virtualize below this many blocks
  *   maxBlocks        (400)   don't virtualize above this (0 = no limit)
- *   handlerVariants  [1-K] (3)  polymorphic handler-body variants (1 = off)
+ *   handlerVariants  [1-64] (3)  polymorphic handler-body variants (1 = off);
+ *                            each dispatch of an opcode within a function
+ *                            picks its variant at runtime (vsel), not once
+ *                            per build
+ *   handlerDecoys    [0-3] (0)  static + live decoy handlers (1: 14 static
+ *                              only; 2: 28 static + 50% opaque-false live
+ *                              guards; 3: reserved; applies to the plain
+ *                              engine, nested engine layer skips)
  *   obfRegIdx        (1)     XOR register indices with a compile-time salt
  *   encDispatch      (1)     encrypt the opcode->handler dispatch table
  *   encBytecode      (1)     AES-128-CTR-encrypt the bytecode stream at load
@@ -348,6 +355,8 @@
  *   e.g.  OBF("vm(preset=max)")
  *   e.g.  OBF("vm(hardened=1, handlerVariants=4, rollingRegKey=1)")
  *   e.g.  OBF("vm(enginePoolSize=4, metamorphicEngines=1, randISA=1)")
+ *   e.g.  OBF("vm(handlerVariants=8, handlerDecoys=2)")  -- variant dispatch
+ *                            + 28 static/live decoy handlers, nestedVM off
  *--------------------------------------------------------------------------*/
 
 /*===----------------------------------------------------------------------===*\

--- a/include/llvm/Transforms/Obfuscator/ObfuscationConfig.h
+++ b/include/llvm/Transforms/Obfuscator/ObfuscationConfig.h
@@ -288,6 +288,7 @@ namespace llvm {
 		bool     obfRegIdx = true;    // XOR register indices with compile-time salt
 		bool     encDispatch = true;   // P2: encrypted per-opcode->handler index indirection (on)
 		unsigned handlerVariants = 3;  // K handler-body variants per opcode (P1 polymorphism on; 1 = off)
+		unsigned handlerDecoys   = 0;  // {0,1,2,3} decoy-handler density (0 = off; 1 static, 2 mixed live, 3 aggressive) — see docs/VM.md
 		bool     encBytecode = true;  // LCG-encrypt bytecode stream at load time
 		bool     constInStream = false;  // move int/i64/fp constants into the encrypted bytecode stream instead of plaintext wrapper stores (requires encBytecode)
 		bool     strongBytecode = true;   // P3: per-position PRF Layer-1 keystream (on; 0 = weak salt^index)

--- a/include/llvm/Transforms/Obfuscator/VMPass_ISA.h
+++ b/include/llvm/Transforms/Obfuscator/VMPass_ISA.h
@@ -134,7 +134,18 @@ namespace llvm {
 	// Max handler-body variants per opcode in the shared __vm_engine.
 	// Statically sizes the 2-D OpcBB arrays. Actual count comes from
 	// VMPassConfig.handlerVariants, clamped to [1, kMaxHandlerVariants].
-	static constexpr unsigned kMaxHandlerVariants = 4;
+	// Ceiling grew from 4 -> 64 to enable intra-function variant dispatch
+	// (M1) and hundreds-of-variants polymorphism.
+	static constexpr unsigned kMaxHandlerVariants = 64;
+
+	// Decoy handlers (M3+). Occupy dispatch-table slots but are never emitted in
+	// bytecode; visible to a static lifter, dead on the real execution path (until
+	// M4 hooks them behind opaque-false guards). Count driven by
+	// VMPassConfig.handlerDecoys (0 = off = zero decoys registered).
+	static constexpr unsigned kMaxDecoys      = 32;
+	static constexpr uint8_t  OP_DECOY_BASE   = 0x38;  // == OP_COUNT
+	static constexpr unsigned OP_COUNT_TOTAL  = (unsigned)OP_DECOY_BASE + kMaxDecoys;  // 0x58
+	static_assert((unsigned)OP_DECOY_BASE == (unsigned)OP_COUNT, "OP_DECOY_BASE must sit immediately after real opcodes");
 
 	// ============================================================================
 	// BinSubop — sub-opcode byte for OP_BINOP and OP_BINOP64

--- a/include/llvm/Transforms/Obfuscator/VMPass_Impl.h
+++ b/include/llvm/Transforms/Obfuscator/VMPass_Impl.h
@@ -243,6 +243,13 @@ namespace llvm {
 			AllocaInst* EngineVMIP = nullptr;
 			AllocaInst* EngineSalt = nullptr;
 
+			// M3: static decoy handlers -- blockaddress-taken, never reachable
+			// via the real dispatch path (fetch clamps P = OIdx % OP_COUNT).
+			// Present a static lifter with extra real-handler-shaped opcodes.
+			SmallVector<BasicBlock*, kMaxDecoys> DecoyBB;
+			unsigned    NumDecoys  = 0;      // active decoy count for this engine (0 = off)
+			AllocaInst* EngineJunk = nullptr; // [NJunk x i32] private sink for decoy stores
+
 			SmallVector<FunctionType*, 16> SharedFTys;
 			DenseMap<FunctionType*, uint8_t> FTyToIdx;
 
@@ -455,6 +462,11 @@ namespace llvm {
 		unsigned CurVariant = 0;    // variant index currently being emitted
 		unsigned NumVariants = 1;   // active variant count (from Cfg, clamped)
 		bool EncDispatch = false;   // == SharedState::EncDispatch for this build
+
+		// M3: static decoy handlers -- see SharedState::DecoyBB.
+		SmallVector<BasicBlock*, kMaxDecoys> DecoyBB;
+		unsigned NumDecoys = 0;     // active decoy count (0 = off / nestedVM)
+		AllocaInst* EngineJunk = nullptr; // [NJunk x i32] private sink, built once in vm.entry
 
 		// Maps every block created during buildOpcodeHandlers() to its variant
 		// index (0..NumVariants-1). Populated by the emission loop; consumed by
@@ -897,6 +909,12 @@ namespace llvm {
 		void buildHandlersFloat();     // all float/freg opcodes (LOADI_F .. FNEG)
 		void buildHandlersCall();      // CALL_VOID CALL_INT CALL_PTR CALL_INT64 CALL_F
 		void buildCall2(VMOp Opc, const Twine& Name, llvm::VMEngine::RetKind2 RK);
+
+		// M3: static decoy handlers (VMPass_Decoys.cpp). computeNumDecoys()
+		// returns 0 when handlerDecoys==0 or nestedVM==1 (byte-identical off);
+		// buildDecoyHandlers() is then a no-op that touches no IR.
+		unsigned computeNumDecoys() const;
+		void buildDecoyHandlers();
 
 		// Nested-VM: pure per-opcode helpers authored fresh + virtualized via a
 		// second VMImpl over the shared engine. See VMPass_Impl.cpp for the

--- a/include/llvm/Transforms/Obfuscator/VMPass_Impl.h
+++ b/include/llvm/Transforms/Obfuscator/VMPass_Impl.h
@@ -916,6 +916,11 @@ namespace llvm {
 		unsigned computeNumDecoys() const;
 		void buildDecoyHandlers();
 
+		// M4: live decoys -- opaque-false-guarded conditional branches from
+		// ~50% of variant-tagged handler blocks into a randomly chosen decoy
+		// (handlerDecoys>=2 only; no-op when NumDecoys==0). See VMPass_Decoys.cpp.
+		void wireLiveDecoys(Function* EF);
+
 		// Nested-VM: pure per-opcode helpers authored fresh + virtualized via a
 		// second VMImpl over the shared engine. See VMPass_Impl.cpp for the
 		// sequencing rationale.


### PR DESCRIPTION
## Summary

Handler polymorphism II for VMPass. Delivers VMProtect-tier variant + decoy handlers requested via the user-facing knobs `handlerVariants` (cap raised 4 → 64) and new `handlerDecoys` (0..3).

Six commits, all green against the 217/221 baseline (only the 4 pre-existing `rt_budget_*` "report dir missing" harness quirks remain). No new regressions at any phase.

## What's shipped

| Commit | Phase | Change |
|---|---|---|
| `7bdd7a3` | M0 | Lift `kMaxHandlerVariants` 4 → 64; add `handlerDecoys` knob 0..3 with clamp; new `kMaxDecoys=32`, `OP_DECOY_BASE=0x38`, `OP_COUNT_TOTAL=0x58` constants. Byte-identical at defaults. |
| `95e3afa` | M1 | Intra-function variant dispatch. Handler table grows from `[OP_COUNT+1]` to `[OP_COUNT*K + 1 + (dmap? OP_COUNT : 0)]`. Runtime `vsel = mix(ip, salt-arg) mod K` at both central and threaded fetch. CALL opcodes pinned to variant K-1 across all K slots. K=1 byte-identical. |
| `7822746` | M2 | Strong diversification: `MbaUtils::applyByIndex` cycles the full 23-identity 7-opcode pool (add/sub/and/or/xor/mul/shl), dropping the `isTargetOpcode` gate for `poolSize > 0`. Adds commutative-swap (bit 3 of `vi`) + `ICmpInst::swapOperands()` arm-invert (bit 2). |
| `ded933f` | M3 | Static decoys: `handlerDecoys=1/2/3` registers 14/28/32 handler-shaped basic blocks in the shared engine. Bodies mirror ADD/LOAD/MOV real handler shapes and sink into a private `[8 x i32] vm.junk` alloca. Unreachable via fetch (`P = OIdx % OP_COUNT` clamp); blockaddress-taken preserves them from DCE. |
| `5bfafc1` | M4 | Live decoys: `wireLiveDecoys` post-pass splits ~50% of variant-tagged handler blocks via `splitBasicBlock(Term)` and replaces the resulting `br` with `condbr(randomHardFalse, decoyBB, m4post)`. Static CFG gains decoy edges; runtime always takes the real path. DSE attacker must solve the opaque predicate to prove the decoy edge dead. Decoy body ends `nextInsn` for defensive fallback. |
| `353dd74` | M6 | `preset=max` opts in `handlerVariants=4, handlerDecoys=2`. Decoy build gate moved from `Cfg.nestedVM` to `engineLayer(EngineId) != 0` so the plain engine gets decoys even when its founding function requested nestedVM (which `preset=max` does). Docs updated: `VM.md` new "Handler Polymorphism II" section, `USER.md` preset row, `obf_annotations.h` knob table. |

## Design highlights

- **K=1 byte-identical guarantee**: dispatch, table sizing, and every new codepath collapse to the  layout when `handlerVariants=1`.
- **`handlerDecoys=0` byte-identical guarantee**: no decoy blocks emitted, no `vm.junk` alloca, `TableSize` unchanged.
- **Salt-arg vs salt-alloca**: M1's vsel reads `HFn->getArg(kParamSalt)` (immutable SSA) not the salt alloca. `hardened=1`'s RDTSC anti-debug XOR-poisons the salt alloca on false-positive scheduler noise; a naive alloca-based vsel would flake every K>1 build under parallel load.
- **CALL pin**: all K slots for CALL opcodes point to variant K-1 because the module-shared `CallSW` switch only wires the last-built variant.
- **`preset=max` benchmarks**: K=4 is the ceiling under the 180s harness cap. K=8 keeps `opt` fast (~65s) but the 373× bloated IR blows past 180s on the downstream `clang -O0` compile. K=16 exceeds 180s in `opt` itself.

## Test plan

- [x] `run_regression.ps1 -Quick` per phase → 217/221 at every commit
- [x] `run_regression.ps1` (full) at M1, M2, M3, M4, M6 → 217/221, zero new failures
- [x] `preset=max` smoke: 28 static decoys + `vm.junk` alloca in plain engine, 0 in nested engine; 183 live-decoy split blocks; linked binary matches unobfuscated output
- [x] `handlerDecoys=1` smoke: 14 `vm.junk` stores + alloca; no `.m4post` blocks (M4 gated at `>=2`)
- [x] Byte-identity spot-check: default annotations produce identical output to `main` tip
- [ ] Real-lift deobf bench rerun on `preset=max` (deferred to post-merge; captures resilience delta vs v0.8.0 baseline)

## Files changed

- `include/llvm/Transforms/Obfuscator/VMPass_ISA.h` — cap lift + decoy constants
- `include/llvm/Transforms/Obfuscator/ObfuscationConfig.h` — `handlerDecoys` field
- `include/llvm/Transforms/Obfuscator/VMPass_Impl.h` — `DecoyBB[]`, `NumDecoys`, method decls
- `VMPass.cpp` — knob parser + preset=max flip
- `VMPass_Dispatch.cpp` — M1 table layout + vsel emission + populateVMEngine hooks
- `VMPass_Wrapper.cpp` — engine-ptr GEP re-based on K
- `VMPass_Harden.cpp` — M2 `applyByIndex` + structural mutations
- `VMPass_Decoys.cpp` (new) — `buildDecoyHandlers` + `wireLiveDecoys` + layer gate
- `CMakeLists.txt` — new source
- `docs/VM.md`, `docs/USER.md`, `docs/obf_annotations.h` — docs