### PR TITLE
fix(vm): strip stale module flags from embedded AES stub before linking

### DIFF
--- a/StringEncryption.cpp
+++ b/StringEncryption.cpp
@@ -506,6 +506,15 @@ namespace {
         StubM->setDataLayout(M.getDataLayout());
         StubM->setTargetTriple(M.getTargetTriple());
 
+        // aes_stub.c is fixed-width (uint8_t/uint32_t) only, so the DL/triple
+        // override above is fully safe -- but leftover module-flag metadata
+        // baked in from whatever host triple built the embedded bitcode (e.g.
+        // wchar_size) can still conflict with M's own flags and make
+        // linkModules() fail on cross-target builds. Drop it; the stub needs
+        // none of its own.
+        if (auto *MDFlags = StubM->getModuleFlagsMetadata())
+            MDFlags->eraseFromParent();
+
         // Link — we only need definitions that are referenced.
         // Linker::Flags::LinkOnlyNeeded avoids pulling in unreferenced symbols.
         if (Linker::linkModules(M, std::move(StubM), 0)) {

--- a/VMPass_Crypto.cpp
+++ b/VMPass_Crypto.cpp
@@ -319,6 +319,14 @@ void VMImpl::buildEncryptCtor() {
 					auto StubM = std::move(*StubOrErr);
 					StubM->setDataLayout(M.getDataLayout());
 					StubM->setTargetTriple(M.getTargetTriple());
+					// aes_stub.c is fixed-width (uint8_t/uint32_t) only, so the
+					// DL/triple override above is fully safe -- but leftover
+					// module-flag metadata baked in from whatever host triple
+					// built the embedded bitcode (e.g. wchar_size) can still
+					// conflict with M's own flags and make linkModules() fail
+					// on cross-target builds. Drop it; the stub needs none.
+					if (auto* MDFlags = StubM->getModuleFlagsMetadata())
+						MDFlags->eraseFromParent();
 					if (Linker::linkModules(M, std::move(StubM), 0)) {
 						errs() << "[vm] linkModules failed for AES stub\n";
 					}


### PR DESCRIPTION
aes_stub.bc is compiled once at CMake time for the host triple. Both VMPass_Crypto.cpp and StringEncryption.cpp already normalize its DataLayout/TargetTriple to match the destination module before linking, but left its stale llvm.module.flags metadata (e.g. wchar_size) intact. On cross-target builds (host != target, e.g. Android NDK aarch64) this conflicts with the destination module's own flags, Linker::linkModules fails, and the in-driver -enable-obfuscation EP path segfaults instead of erroring cleanly.

aes_stub.c only uses fixed-width uint8_t/uint32_t types (no long/size_t), so dropping the stub's module flags is safe -- it needs none of its own.

Fixes #12